### PR TITLE
modify ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,16 +32,9 @@ workflows:
   version: 2
   test_and_release:
     jobs:
-    - test:
-        filters:
-          branches:
-            only: /.*/
-          tags:
-            only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+    - test
     - release:
         filters:
-          branches:
-            ignore: /.*/
           tags:
             only: /v[0-9]+(\.[0-9]+)*(-.*)*/
         requires:


### PR DESCRIPTION
- Test should run on all branches/tags. So the filter is not really needed...
- release process already has the `only` annotation on tag so it should ignore any branches without `ignore`.
- Add new line at EOF for POSIX compatibility.
  - Ref
    - http://hiroakiuno.hatenablog.com/entry/20070409/p1
    - https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline