### PR TITLE
Fix docs

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -1,0 +1,174 @@
+
+# Checkpoint Details
+
+## Docker Image Checkpoints
+
+These checkpoints refered to [CIS Docker 1.13.0 Benchmark v1.0.0](https://www.cisecurity.org/benchmark/docker/).
+
+### CIS-DI-0001: Create a user for the container
+
+> Create a non-root user for the container in the Dockerfile for the container image.
+>
+> It is a good practice to run the container as a non-root user, if possible.
+
+```
+# Dockerfile
+RUN useradd -d /home/dockle -m -s /bin/bash dockle
+USER dockle
+
+or
+
+RUN addgroup -S dockle && adduser -S -G dockle dockle
+USER dockle
+
+```
+
+### CIS-DI-0002: Use trusted base images for containers
+
+Dockle checks [Content Trust](https://docs.docker.com/engine/security/trust/content_trust/).
+Please check with [Trivy](https://github.com/knqyf263/trivy).
+
+### CIS-DI-0003: Do not install unnecessary packages in the container
+
+Not supported.
+
+### CIS-DI-0004: Scan and rebuild the images to include security patches
+
+Not supported.
+Please check with [Trivy](https://github.com/knqyf263/trivy).
+
+### CIS-DI-0005: Enable Content trust for Docker
+
+> Content trust is disabled by default. You should enable it.
+
+```bash
+$ export DOCKER_CONTENT_TRUST=1
+```
+
+- https://docs.docker.com/engine/security/trust/content_trust/#about-docker-content-trust-dct
+
+    > Docker Content Trust (DCT) provides the ability to use digital signatures for data sent to and received from remote Docker registries.<br/>
+    > Engine Signature Verification prevents the following:
+    >
+    >   - `$ docker container run` of an unsigned image.
+    >   - `$ docker pull` of an unsigned image.
+    >   - `$ docker build` where the FROM image is not signed or is not scratch.
+
+### CIS-DI-0006: Add `HEALTHCHECK` instruction to the container image
+
+> Add `HEALTHCHECK` instruction in your docker container images to perform the health check on running containers.<br/>
+> Based on the reported health status, the docker engine could then exit non-working containers and instantiate new ones.
+
+```
+# Dockerfile
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost/ || exit 1
+```
+
+### CIS-DI-0007: Do not use `update` instructions alone in the Dockerfile
+
+> Do not use `update` instructions such as `apt-get update` alone or in a single line in the Dockerfile.<br/>
+> Adding the `update` instructions in a single line on the Dockerfile will cache the update layer.
+
+```bash
+RUN apt-get update && apt-get install -y package-a
+```
+
+### CIS-DI-0008: Remove `setuid` and `setgid` permissions in the images
+
+> Removing `setuid` and `setgid` permissions in the images would prevent privilege escalation attacks in the containers.<br/>
+> `setuid` and `setgid` permissions could be used for elevating privileges.
+
+```bash
+chmod u-s setuid-file
+chmod u-g setgid-file
+```
+
+### CIS-DI-0009: Use `COPY` instead of `ADD` in Dockerfile
+
+> Use `COPY` instruction instead of `ADD` instruction in the Dockerfile.<br/>
+> `ADD` instruction introduces risks such as adding malicious files from URLs without scanning and unpacking procedure vulnerabilities.
+
+```
+# Dockerfile
+ADD test.json /app/test.json
+↓
+COPY test.json /app/test.json
+```
+
+### CIS-DI-0010: Do not store secrets in Dockerfiles
+
+> Do not store any secrets in Dockerfiles.<br/>
+> the secrets within these Dockerfiles could be easily exposed and potentially be exploited.
+
+`Dockle` checks ENVIRONMENT variables and credential files.
+
+### CIS-DI-0011: Install verified packages only
+
+Not supported.
+It's better to use [Trivy](https://github.com/knqyf263/trivy).
+
+## Dockle Checkpoints for Docker
+
+These checkpoints referred to [Docker Best Practice](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) and so on.
+
+### DKL-DI-0001: Avoid `sudo` command
+
+- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
+
+    > Avoid installing or using sudo as it has unpredictable TTY and signal-forwarding behavior that can cause problems.
+
+### DKL-DI-0002: Avoid sensitive directory mounting
+
+A volume mount makes weak points. This depends on mounting volumes.
+
+Currently, `Dockle` checks following directories:
+
+ - `/boot`, `/dev`, `/etc`, `/lib`, `/proc`, `/sys`,  `/usr`
+
+`dockle` only checks `VOLUME` statements, since we can't check `docker run -v /lib:/lib ...`.
+
+
+### DKL-DI-0003: Avoid `apt-get upgrade`, `apk upgrade`, `dist-upgrade`
+
+- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get
+
+    > Avoid `RUN apt-get upgrade` and `dist-upgrade`, as many of the “essential” packages from the parent images cannot upgrade inside an unprivileged container.
+
+### DKL-DI-0004: Use `apk add` with `--no-cache`
+
+- https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache
+
+    > As of Alpine Linux 3.3 there exists a new `--no-cache` option for `apk`. It allows users to install packages with an index that is updated and used on-the-fly and not cached locally:<br/>
+    > ...<br/>
+    > This avoids the need to use `--update` and remove `/var/cache/apk/*` when done installing packages.
+
+### DKL-DI-0005: Clear `apt-get` caches
+
+Use `apt-get clearn && rm -rf /var/lib/apt/lists/*` after `apt-get install`.
+
+- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get
+
+    > In addition, when you clean up the `apt cache` by removing `/var/lib/apt/lists` it reduces the image size, since the apt cache is not stored in a layer. Since the `RUN` statement starts with `apt-get update`, the package cache is always refreshed prior to `apt-get install`.
+
+### DKL-DI-0006: Avoid `latest` tag
+
+- https://vsupalov.com/docker-latest-tag/
+
+    > Docker images tagged with `:latest` have caused many people a lot of trouble.
+
+## Dockle Checkpoints for Linux
+
+These checkpoints referred to [Linux Best Practices](https://www.cyberciti.biz/tips/linux-security.html) and so on.
+
+### DKL-LI-0001: Avoid empty password
+
+- https://blog.aquasec.com/cve-2019-5021-alpine-docker-image-vulnerability
+
+    > CVE-2019-5021: Alpine Docker Image "null root password" Vulnerability
+
+### DKL-LI-0002: Be unique UID/GROUPs
+
+- http://www.linfo.org/uid.html
+
+    > Contrary to popular belief, it is not necessary that each entry in the UID field be unique. However, non-unique UIDs can cause security problems, and thus UIDs should be kept unique across the entire organization.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,0 +1,337 @@
+# Detailed Usages and Examples
+
+## TOC
+
+- Common Examples
+  - Scan an image
+  - Scan an image file
+  - Get or Save the results as JSON
+  - Specify exit code
+  -  Ignore the specified checkpoints
+  - Clear image caches
+- Continuous Integration (CI)
+  - Travis CI
+  - CircleCI
+- Authorization for Private Docker Registry
+  - Docker Hub
+  - Amazon ECR (Elastic Container Registry)
+  - GCR (Google Container Registry)
+  - Self Hosted Registry (BasicAuth)
+
+## Common Examples
+
+### Scan an image
+
+Simply specify an image name (and a tag).
+
+```bash
+$ dockle goodwithtech/test-image:v1
+```
+
+<details>
+<summary>Result</summary>
+
+```
+FATAL   - CIS-DI-0001: Create a user for the container
+        * Last user should not be root
+WARN    - CIS-DI-0005: Enable Content trust for Docker
+        * export DOCKER_CONTENT_TRUST=1 before docker pull/build
+FATAL   - CIS-DI-0006: Add HEALTHCHECK instruction to the container image
+        * not found HEALTHCHECK statement
+FATAL   - CIS-DI-0007: Do not use update instructions alone in the Dockerfile
+        * Use 'Always combine RUN 'apt-get update' with 'apt-get install' : /bin/sh -c apt-get update && apt-get install -y git
+FATAL   - CIS-DI-0008: Remove setuid and setgid permissions in the images
+        * Found setuid file: etc/passwd grw-r--r--
+        * Found setuid file: usr/lib/openssh/ssh-keysign urwxr-xr-x
+        * Found setuid file: app/hoge.txt ugrw-r--r--
+        * Found setuid file: app/hoge.txt ugrw-r--r--
+        * Found setuid file: etc/shadow urw-r-----
+FATAL   - CIS-DI-0009: Use COPY instead of ADD in Dockerfile
+        * Use COPY : /bin/sh -c #(nop) ADD file:81c0a803075715d1a6b4f75a29f8a01b21cc170cfc1bff6702317d1be2fe71a3 in /app/credentials.json
+FATAL   - CIS-DI-0010: Do not store secrets in ENVIRONMENT variables
+        * Suspicious ENV key found : MYSQL_PASSWD
+FATAL   - CIS-DI-0010: Do not store secret files
+        * Suspicious filename found : app/credentials.json
+PASS    - DKL-DI-0001: Avoid sudo command
+FATAL   - DKL-DI-0002: Avoid sensitive directory mounting
+        * Avoid mounting sensitive dirs : /usr
+PASS    - DKL-DI-0003: Avoid apt-get/apk/dist-upgrade
+PASS    - DKL-DI-0004: Use apk add with --no-cache
+FATAL   - DKL-DI-0005: Clear apt-get caches
+        * Use 'apt-get clean && rm -rf /var/lib/apt/lists/*' : /bin/sh -c apt-get update && apt-get install -y git
+PASS    - DKL-DI-0006: Avoid latest tag
+FATAL   - DKL-LI-0001: Avoid empty password
+        * No password user found! username : nopasswd
+PASS    - DKL-LI-0002: Be unique UID
+PASS    - DKL-LI-0002: Be unique GROUP
+```
+</details>
+
+### Scan an image file
+
+```bash
+$ docker save alpine:latest -o alpine.tar
+$ dockle --input alpine.tar
+```
+
+### Get or Save the results as JSON
+
+```bash
+$ dockle -f json goodwithtech/test-image:v1
+$ dockle -f json -o results.json goodwithtech/test-image:v1
+```
+
+<details>
+<summary>Result</summary>
+
+```json
+{
+  "summary": {
+    "fatal": 6,
+    "warn": 2,
+    "info": 2,
+    "pass": 7
+  },
+  "details": [
+    {
+      "code": "CIS-DI-0001",
+      "title": "Create a user for the container",
+      "level": "WARN",
+      "alerts": [
+        "Last user should not be root"
+      ]
+    },
+    {
+      "code": "CIS-DI-0005",
+      "title": "Enable Content trust for Docker",
+      "level": "INFO",
+      "alerts": [
+        "export DOCKER_CONTENT_TRUST=1 before docker pull/build"
+      ]
+    },
+    {
+      "code": "CIS-DI-0006",
+      "title": "Add HEALTHCHECK instruction to the container image",
+      "level": "WARN",
+      "alerts": [
+        "not found HEALTHCHECK statement"
+      ]
+    },
+    {
+      "code": "CIS-DI-0008",
+      "title": "Remove setuid and setgid permissions in the images",
+      "level": "INFO",
+      "alerts": [
+        "Found setuid file: usr/lib/openssh/ssh-keysign urwxr-xr-x"
+      ]
+    },
+    {
+      "code": "CIS-DI-0009",
+      "title": "Use COPY instead of ADD in Dockerfile",
+      "level": "FATAL",
+      "alerts": [
+        "Use COPY : /bin/sh -c #(nop) ADD file:81c0a803075715d1a6b4f75a29f8a01b21cc170cfc1bff6702317d1be2fe71a3 in /app/credentials.json "
+      ]
+    },
+    {
+      "code": "CIS-DI-0010",
+      "title": "Do not store secrets in ENVIRONMENT variables",
+      "level": "FATAL",
+      "alerts": [
+        "Suspicious ENV key found : MYSQL_PASSWD"
+      ]
+    },
+    {
+      "code": "CIS-DI-0010",
+      "title": "Do not store secret files",
+      "level": "FATAL",
+      "alerts": [
+        "Suspicious filename found : app/credentials.json "
+      ]
+    },
+    {
+      "code": "DKL-DI-0002",
+      "title": "Avoid sensitive directory mounting",
+      "level": "FATAL",
+      "alerts": [
+        "Avoid mounting sensitive dirs : /usr"
+      ]
+    },
+    {
+      "code": "DKL-DI-0005",
+      "title": "Clear apt-get caches",
+      "level": "FATAL",
+      "alerts": [
+        "Use 'rm -rf /var/lib/apt/lists' after 'apt-get install' : /bin/sh -c apt-get update \u0026\u0026 apt-get install -y git"
+      ]
+    },
+    {
+      "code": "DKL-LI-0001",
+      "title": "Avoid empty password",
+      "level": "FATAL",
+      "alerts": [
+        "No password user found! username : nopasswd"
+      ]
+    }
+  ]
+}
+```
+
+</details>
+
+### Specify exit code
+
+By default, `Dockle` exits with code `0` even if there are some problems.
+
+Use the `--exit-code` option to exit with a non-zero exit code if any alert were found.
+
+```bash
+$ dockle  -exist-code 1 [IMAGE_NAME]
+```
+
+### Ignore the specified checkpoints
+
+Use `.dockleignore` file.
+
+```bash
+$ cat .dockleignore
+# set root to default user because we want to run nginx
+CIS-DI-0001
+# Use latest tag because to check the image inside only
+DKL-DI-0006
+```
+
+### Clear image caches
+
+The `--clear-cache` option removes image caches. Use this option if the image with the same tag is updated (such as `latest` tag).
+
+```bash
+$ dockle --clear-cache python:3.7
+```
+
+## Continuous Integration (CI)
+
+You can scan your built image with `Dockle` in Travis CI/CircleCI.
+
+In these examples, the test will fail with if any warnings were found.
+
+Though, you can ignore the specified target checkpoints by using `.dockleignore` file.
+
+Or, if you just want the results to display and not let the test fail for this, specify `--exit-code` to `0` in `dockle` command.
+
+### Travis CI
+
+```yaml
+services:
+  - docker
+
+env:
+  global:
+    - COMMIT=${TRAVIS_COMMIT::8}
+
+before_install:
+  - docker build -t dockle-ci-test:${COMMIT} .
+  - export VERSION=$(curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+  - wget https://github.com/goodwithtech/dockle/releases/download/v${VERSION}/dockle_${VERSION}_Linux-64bit.tar.gz
+  - tar zxvf dockle_${VERSION}_Linux-64bit.tar.gz
+script:
+  - ./dockle dockle-ci-test:${COMMIT}
+  - ./dockle --exit-code 1 dockle-ci-test:${COMMIT}
+```
+
+- Example: https://travis-ci.org/goodwithtech/dockle-ci-test
+- Repository: https://github.com/goodwithtech/dockle-ci-test
+
+### CircleCI
+
+```yaml
+jobs:
+  build:
+    docker:
+      - image: docker:18.09-git
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build image
+          command: docker build -t dockle-ci-test:${CIRCLE_SHA1} .
+      - run:
+          name: Install dockle
+          command: |
+            apk add --update curl
+            VERSION=$(
+                curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | \
+                grep '"tag_name":' | \
+                sed -E 's/.*"v([^"]+)".*/\1/'
+            )
+            wget https://github.com/goodwithtech/dockle/releases/download/v${VERSION}/dockle_${VERSION}_Linux-64bit.tar.gz
+            tar zxvf dockle_${VERSION}_Linux-64bit.tar.gz
+            mv dockle /usr/local/bin
+      - run:
+          name: Scan the local image with dockle
+          command: dockle --exit-code 1 dockle-ci-test:${CIRCLE_SHA1}
+workflows:
+  version: 2
+  release:
+    jobs:
+      - build
+```
+
+- Example: https://circleci.com/gh/goodwithtech/dockle-ci-test
+- Repository: https://github.com/goodwithtech/dockle-ci-test
+
+## Authorization for Private Docker Registry
+
+`Dockle` can download images from a private registry, without installing `Docker` or any other 3rd party tools. It's designed so for ease of use in a CI process.
+
+All you have to do is: install `Dockle` and set ENVIRONMENT variables.
+
+- NOTE: I don't recommend using ENV vars in your local machine.
+
+### Docker Hub
+
+To download the private repository from Docker Hub, you need to set `DOCKLE_AUTH_URL`, `DOCKLE_USERNAME` and `DOCKLE_PASSWORD` ENV vars.
+
+
+```bash
+export DOCKLE_AUTH_URL=https://registry.hub.docker.com
+export DOCKLE_USERNAME={DOCKERHUB_USERNAME}
+export DOCKLE_PASSWORD={DOCKERHUB_PASSWORD}
+```
+
+- NOTE: You don't need to set ENV vars when downloading from the public repository.
+
+### Amazon ECR (Elastic Container Registry)
+
+`Dockle` uses the AWS SDK. You don't need to install `aws` CLI tool.
+
+Use [AWS CLI's ENVIRONMENT variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
+
+```bash
+export AWS_ACCESS_KEY_ID={AWS ACCESS KEY}
+export AWS_SECRET_ACCESS_KEY={SECRET KEY}
+export AWS_DEFAULT_REGION={AWS REGION}
+```
+
+### GCR (Google Container Registry)
+
+`Dockle` uses the Google Cloud SDK. So, you don't need to install `gcloud` command.
+
+If you'd like to use the target project's repository, you can settle via `GOOGLE_APPLICATION_CREDENTIAL`.
+
+```bash
+# must set DOCKLE_USERNAME empty char
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credential.json
+```
+
+### Self Hosted Registry (BasicAuth)
+
+BasicAuth server needs `DOCKLE_USERNAME` and `DOCKLE_PASSWORD`.
+
+```bash
+export DOCKLE_USERNAME={USERNAME}
+export DOCKLE_PASSWORD={PASSWORD}
+
+# if you'd like to use 80 port, use NonSSL
+export DOCKLE_NON_SSL=true
+```

--- a/README.md
+++ b/README.md
@@ -7,19 +7,21 @@
 
 > Dockle - Simple Security Auditing and helping build the Best Docker Images  
 
-`Dockle` helps you
-1) Build secure Docker images
+`Dockle` helps you:
+
+1. Build secure Docker images
     - Checkpoints includes [CIS Benchmarks](https://www.cisecurity.org/cis-benchmarks/)
-2) Build [Best Practice](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) Docker images
+2. Build [Best Practice](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) Docker images
 
-You can check a docker image only run... 
-```bash
-$ brew install goodwithtech/dockle/dockle
-$ dockle [YOUR_IMAGE_NAME]
-``` 
+To check your Docker image, only run:
 
-<img src="imgs/usage_pass_light.png" width="800">
-<img src="imgs/usage_fail_light.png" width="800">
+  ```bash
+  $ brew install goodwithtech/dockle/dockle
+  $ dockle [YOUR_IMAGE_NAME]
+  ``` 
+
+  <img src="imgs/usage_pass_light.png" width="800">
+  <img src="imgs/usage_fail_light.png" width="800">
 
 
 # TOC
@@ -60,11 +62,11 @@ $ dockle [YOUR_IMAGE_NAME]
 # Features
 
 - Detect container's vulnerabilities
-- Helping build Dockerfile best-practice
-- Simple
-  - Specify only an image name
+- Helping build best-practice Dockerfile
+- Simple usage
+  - Specify only the image name
   - See [Quick Start](#quick-start) and [Examples](#examples)
-- Support CIS Benchmarks
+- CIS Benchmarks Support
   - High accuracy
 - DevSecOps
   - Suitable for CI such as Travis CI, CircleCI, Jenkins, etc.
@@ -72,8 +74,6 @@ $ dockle [YOUR_IMAGE_NAME]
 
 
 # Comparison
-
-
 
 |  | [Dockle](https://github.com/goodwithtech/dockle) | [Hadolint](https://github.com/hadolint/hadolint) | [Docker Bench for Security](https://github.com/docker/docker-bench-security) |
 |--- |---:|---:|---:|
@@ -111,9 +111,12 @@ All checkpoints [here](#checkpoint-summary)!
 
 ## Linuxbrew
 
+You can use [Homebrew](https://docs.brew.sh/Homebrew-on-Linux) on Linux and WSL(Windows Subsystem for Linux).
+
 ```bash
 $ brew install goodwithtech/dockle/dockle
 ```
+
 ## RHEL/CentOS
 
 ```bash
@@ -137,7 +140,7 @@ $ sudo dpkg -i dockle.deb && rm dockle.deb
 
 ## Mac OS X / Homebrew
 
-You can use homebrew on Mac OS.
+You can use [Homebrew](https://brew.sh/) on macOS.
 
 ```
 $ brew install goodwithtech/dockle/dockle
@@ -155,11 +158,13 @@ $ unzip dockle.zip && rm dockle.zip
 $ ./dockle.exe [IMAGE_NAME]
 ```
 
-
 ## Binary
 
-Get the latest version from [this page](https://github.com/goodwithtech/dockle/releases/latest), and download the archive file for your operating system/architecture. Unpack the archive, and put the binary somewhere in your `$PATH` (on UNIX-y systems, /usr/local/bin or the like). Make sure it has execution bits turned on.
+You can get the latest version binary from [this page](https://github.com/goodwithtech/dockle/releases/latest).
 
+Download the archive file for your operating system/architecture. Unpack the archive, and put the binary somewhere in your `$PATH` (on UNIX-y systems, `/usr/local/bin` or the like).
+
+- NOTE: Make sure that it's execution bits turned on. (`chmod +x dockle`)
 
 ## From source
 
@@ -231,7 +236,7 @@ If you would like to scan the image on your host machine, you need to mount `doc
 $ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock ...
 ```
 
-Please re-pull latest `goodwithtech/dockle` if an error occured.
+Please, re-pull latest `goodwithtech/dockle` if an error occurs.
 
 # Checkpoint Summary
 
@@ -326,7 +331,7 @@ $ docker save alpine:latest -o alpine.tar
 $ dockle --input alpine.tar
 ```
 
-## Save the results as JSON
+## Get or Save the results as JSON
 
 ```bash
 $ dockle -f json goodwithtech/test-image:v1
@@ -431,8 +436,10 @@ $ dockle -f json -o results.json goodwithtech/test-image:v1
 </details>
 
 ## Specify exit code
-By default, `Dockle` exits with code 0 even if there are some problems.
-Use the --exit-code option if you may want to exit with a non-zero exit code.
+
+By default, `Dockle` exits with code `0` even if there are some problems.
+
+Use the `--exit-code` option to exit with a non-zero exit code if any alert were found.
 
 ```bash
 $ dockle  -exist-code 1 [IMAGE_NAME]
@@ -446,7 +453,7 @@ Use `.dockleignore`.
 $ cat .dockleignore
 # set root to default user because we want to run nginx
 CIS-DI-0001
-# Use latest tag because only check for image inside
+# Use latest tag because to check only the image inside
 DKL-DI-0006
 ```
 
@@ -461,7 +468,7 @@ $ dockle --clear-cache python:3.7
 # Continuous Integration (CI)
 
 Scan your image built in Travis CI/CircleCI. 
-The test will fail with if a error is found.
+The test will fail with if an error is found.
 You can skip target checkpoint if you use `.dockleignore`.
  
 When you don't would like to fail the test, specify `--exit-code 0`.
@@ -487,8 +494,8 @@ script:
   - ./dockle --exit-code 1 dockle-ci-test:${COMMIT}
 ```
 
-Example: https://travis-ci.org/goodwithtech/dockle-ci-test<br/>
-Repository: https://github.com/goodwithtech/dockle-ci-test
+- Example: https://travis-ci.org/goodwithtech/dockle-ci-test
+- Repository: https://github.com/goodwithtech/dockle-ci-test
 
 ## CircleCI
 
@@ -525,12 +532,12 @@ workflows:
       - build
 ```
 
-Example : https://circleci.com/gh/goodwithtech/dockle-ci-test<br/>
-Repository: https://github.com/goodwithtech/dockle-ci-test
+- Example: https://circleci.com/gh/goodwithtech/dockle-ci-test
+- Repository: https://github.com/goodwithtech/dockle-ci-test
 
 ## Authorization for Private Docker Registry
 
-`Dockle` can download images from private registry, without installing `Docker` and any 3rd party tools.
+`Dockle` can download images from a private registry, without installing `Docker` and any 3rd party tools.
 That's because it's easy to run in a CI process.
 
 All you have to do is install `Dockle` and set ENVIRONMENT variables.
@@ -538,8 +545,9 @@ But, I can't recommend using ENV vars in your local machine to you.
 
 ### Docker Hub
 
-Docker Hub needs `DOCKLE_AUTH_URL`, `DOCKLE_USERNAME` and `DOCKLE_PASSWORD`.
-You don't need to set ENV vars when download from public repository.
+You don't need to set ENV vars as below when downloading from the public repository.
+
+For the private repository, Docker Hub needs `DOCKLE_AUTH_URL`, `DOCKLE_USERNAME` and `DOCKLE_PASSWORD`.
 
 ```bash
 export DOCKLE_AUTH_URL=https://registry.hub.docker.com
@@ -556,7 +564,8 @@ You can use [AWS CLI's ENVIRONMENT variables](https://docs.aws.amazon.com/cli/la
 
 `Dockle` uses Google Cloud SDK. So, you don't need to install `gcloud` command.
 
-If you would like to use target project's repository, you can settle via `GOOGLE_APPLICATION_CREDENTIAL`. 
+If you would like to use the target project's repository, you can settle via `GOOGLE_APPLICATION_CREDENTIAL`. 
+
 ```bash
 # must set DOCKLE_USERNAME empty char
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credential.json
@@ -582,8 +591,10 @@ These checkpoints refered to [CIS Docker 1.13.0 Benchmark v1.0.0](https://www.ci
 
 ### CIS-DI-0001: Create a user for the container
 
-> Create a non-root user for the container in the Dockerfile for the container image.<br/>
+> Create a non-root user for the container in the Dockerfile for the container image.
+>
 > It is a good practice to run the container as a non-root user, if possible. 
+
 ```
 # Dockerfile
 RUN useradd -d /home/dockle -m -s /bin/bash dockle
@@ -596,10 +607,9 @@ USER dockle
 
 ```
 
-
 ### CIS-DI-0002: Use trusted base images for containers
 
-Dockle checks Content Trust. 
+Dockle checks [Content Trust](https://docs.docker.com/engine/security/trust/content_trust/). 
 Please check with [Trivy](https://github.com/knqyf263/trivy).
 
 ### CIS-DI-0003: Do not install unnecessary packages in the container
@@ -628,7 +638,8 @@ https://docs.docker.com/engine/security/trust/content_trust/#about-docker-conten
 
 ### CIS-DI-0006: Add HEALTHCHECK instruction to the container image
 
-> Add `HEALTHCHECK` instruction in your docker container images to perform the health check on running containers.<br/>
+> Add `HEALTHCHECK` instruction in your docker container images to perform the health check on running containers.
+>
 > Based on the reported health status, the docker engine could then exit non-working containers and instantiate new ones.
 ```
 # Dockerfile
@@ -638,7 +649,8 @@ HEALTHCHECK --interval=5m --timeout=3s \
 
 ### CIS-DI-0007: Do not use update instructions alone in the Dockerfile
 
-> Do not use update instructions such as apt-get update alone or in a single line in the Dockerfile.<br/>
+> Do not use update instructions such as `apt-get update` alone or in a single line in the Dockerfile.
+> 
 > Adding the update instructions in a single line on the Dockerfile will cache the update layer.
 ```bash
 RUN apt-get update && apt-get install -y package-a
@@ -655,7 +667,8 @@ chmod u-g setgid-file
 
 ### CIS-DI-0009: Use COPY instead of ADD in Dockerfile
 
-> Use COPY instruction instead of ADD instruction in the Dockerfile.<br/>
+> Use COPY instruction instead of ADD instruction in the Dockerfile.
+>
 > `ADD` instruction introduces risks such as adding malicious files from URLs without scanning and unpacking procedure vulnerabilities.
 ```
 # Dockerfile
@@ -678,7 +691,7 @@ It's better to use [Trivy](https://github.com/knqyf263/trivy).
 
 ## Dockle Checkpoints for Docker
 
-These checkpoints refered to [Docker Best Practice](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) and so on.
+These checkpoints referred to [Docker Best Practice](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) and so on.
 
 ### DKL-DI-0001: Avoid `sudo` command
 
@@ -687,11 +700,11 @@ https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
 
 ### DKL-DI-0002: Avoid sensitive directory mounting
 
-A volume mount makes weakpoints. 
+A volume mount makes weak points. 
 This depends on mounting volumes.
 Currently, `Dockle` checks following directories.
 
-`/boot`,`/dev`,`/etc`,`/lib`,`/proc`,`/sys`, `/usr`
+`/boot`, `/dev`, `/etc`, `/lib`, `/proc`, `/sys`,  `/usr`
 
 `dockle` only checks `VOLUME` statements. We can't check `docker run -v /lib:/lib ...`.
 
@@ -700,21 +713,21 @@ Currently, `Dockle` checks following directories.
 
 https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get
  
-> Avoid RUN apt-get upgrade and dist-upgrade, as many of the “essential” packages from the parent images cannot upgrade inside an unprivileged container.
+> Avoid `RUN apt-get upgrade` and `dist-upgrade`, as many of the “essential” packages from the parent images cannot upgrade inside an unprivileged container.
 
 ### DKL-DI-0004: Use apk add with `--no-cache`
 
 https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache
 
-> As of Alpine Linux 3.3 there exists a new --no-cache option for apk. It allows users to install packages with an index that is updated and used on-the-fly and not cached locally:
-> This avoids the need to use --update and remove /var/cache/apk/* when done installing packages.
+> As of Alpine Linux 3.3 there exists a new `--no-cache` option for `apk`. It allows users to install packages with an index that is updated and used on-the-fly and not cached locally:
+> This avoids the need to use `--update` and remove `/var/cache/apk/*` when done installing packages.
 
 ### DKL-DI-0005: Clear apt-get caches
 
-Use “apt-get clearn && rm -rf /var/lib/apt/lists/*` if use apt-get install
+Use `apt-get clearn && rm -rf /var/lib/apt/lists/*` after `apt-get install`.
 
 https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get
-> In addition, when you clean up the apt cache by removing /var/lib/apt/lists it reduces the image size, since the apt cache is not stored in a layer. Since the RUN statement starts with apt-get update, the package cache is always refreshed prior to apt-get install.
+> In addition, when you clean up the `apt cache` by removing `/var/lib/apt/lists` it reduces the image size, since the apt cache is not stored in a layer. Since the RUN statement starts with apt-get update, the package cache is always refreshed prior to `apt-get install`.
 
 
 ### DKL-DI-0006: Avoid `latest` tag
@@ -725,7 +738,7 @@ https://vsupalov.com/docker-latest-tag/
 
 ## Dockle Checkpoints for Linux
 
-These checkpoints refered to [Linux Best Practices](https://www.cyberciti.biz/tips/linux-security.html) and so on.
+These checkpoints referred to [Linux Best Practices](https://www.cyberciti.biz/tips/linux-security.html) and so on.
 
 ### DKL-LI-0001: Avoid empty password 
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To check your Docker image, only run:
 | Target |  BuildImage | Dockerfile | Host<br/>DockerDaemon<br/>BuildImage<br/>ContainerRuntime |
 | How to run | Binary | Binary | ShellScript |
 | Dependency | No | No | Some dependencies |
-| Suitable CI | ✓ | ✓ | x |
+| CI Suitable | ✓ | ✓ | x |
 | Purpose |SecurityAudit<br/>DockerfileLint| DockerfileLint | SecurityAudit<br />DockerfileLint |
 | Covered CIS Benchmarks(Docker Image and Build File) | 7 | 3 | 5 |
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ Download the archive file for your operating system/architecture. Unpack the arc
 ## From source
 
 ```bash
-$ go get -u github.com/goodwithtech/dockle
+$ GO111MODULE=off go get github.com/goodwithtech/dockle/cmd/dockle
+$ cd $GOPATH/src/github.com/goodwithtech/dockle && GO111MODULE=on go build -o $GOPATH/bin/dockle cmd/dockle/main.go
 ```
 
 ## Use Docker
@@ -175,7 +176,11 @@ $ go get -u github.com/goodwithtech/dockle
 There's a [`Dockle` image on Docker Hub](https://hub.docker.com/r/goodwithtech/dockle) also. You can try `dockle` before installing the command.
 
 ```
-$ docker pull goodwithtech/dockle:latest
+$ VERSION=$(
+ curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | \
+ grep '"tag_name":' | \
+ sed -E 's/.*"v([^"]+)".*/\1/' \
+) && docker run --rm goodwithtech/dockle:${VERSION} [YOUR_IMAGE_NAME]
 ```
 
 # Quick Start
@@ -231,19 +236,29 @@ PASS    - Be unique GROUP
 Also, you can use Docker to use `dockle` command as follow.
 
 ```bash
-$ docker run --rm goodwithtech/dockle [YOUR_IMAGE_NAME]
+$ export DOCKLE_LATEST=$(
+ curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | \
+ grep '"tag_name":' | \
+ sed -E 's/.*"v([^"]+)".*/\1/' \
+)
+$ docker run --rm goodwithtech/dockle:${DOCKLE_LATEST} [YOUR_IMAGE_NAME]
 ```
 
 For more suitable use, I suggest mounting a cache directory. Replace `[YOUR_CACHE_DIR]` below with the cache directory on your machine.
 
 ```bash
-$ docker run --rm -v [YOUR_CACHE_DIR]:/root/.cache/ goodwithtech/dockle [YOUR_IMAGE_NAME]
+$ export DOCKLE_LATEST=$(
+ curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | \
+ grep '"tag_name":' | \
+ sed -E 's/.*"v([^"]+)".*/\1/' \
+)
+$ docker run --rm -v [YOUR_CACHE_DIR]:/root/.cache/ goodwithtech/dockle:${DOCKLE_LATEST} [YOUR_IMAGE_NAME]
 ```
 
 - Example for macOS:
 
     ```bash
-    $ docker run --rm -v $HOME/Library/Caches:/root/.cache/ goodwithtech/dockle [YOUR_IMAGE_NAME]
+    $ docker run --rm -v $HOME/Library/Caches:/root/.cache/ goodwithtech/dockle:${DOCKLE_LATEST} [YOUR_IMAGE_NAME]
     ```
 
 - If you'd like to scan the image on your host machine, you need to mount `docker.sock`.
@@ -251,9 +266,6 @@ $ docker run --rm -v [YOUR_CACHE_DIR]:/root/.cache/ goodwithtech/dockle [YOUR_IM
     ```bash
     $ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock ...
     ```
-
-- NOTE: `Dockle` is often updated. Please, re-pull the latest `goodwithtech/dockle` if an error occurs.
-
 
 # Checkpoint Summary
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-<img src="imgs/logo.png" width="450">
+<img src="https://raw.githubusercontent.com/goodwithtech/dockle/master/imgs/logo.png" width="450">
 
 [![GitHub release](https://img.shields.io/github/release/goodwithtech/dockle.svg)](https://github.com/goodwithtech/dockle/releases/latest)
 [![CircleCI](https://circleci.com/gh/goodwithtech/dockle.svg?style=svg)](https://circleci.com/gh/goodwithtech/dockle)
 [![Go Report Card](https://goreportcard.com/badge/github.com/goodwithtech/dockle)](https://goreportcard.com/report/github.com/goodwithtech/dockle)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-> Dockle - Simple Security Auditing and helping build the Best Docker Images  
+> Dockle - Simple Security Auditing and helping build the Best Docker Images
 
 `Dockle` helps you:
 
@@ -15,13 +15,13 @@
 
 To check your Docker image, only run:
 
-  ```bash
-  $ brew install goodwithtech/dockle/dockle
-  $ dockle [YOUR_IMAGE_NAME]
-  ``` 
+```bash
+$ brew install goodwithtech/dockle/dockle
+$ dockle [YOUR_IMAGE_NAME]
+```
 
-  <img src="imgs/usage_pass_light.png" width="800">
-  <img src="imgs/usage_fail_light.png" width="800">
+<img src="https://raw.githubusercontent.com/goodwithtech/dockle/master/imgs/usage_pass_light.png" width="800">
+<img src="https://raw.githubusercontent.com/goodwithtech/dockle/master/imgs/usage_fail_light.png" width="800">
 
 
 # TOC
@@ -36,28 +36,28 @@ To check your Docker image, only run:
   - [Windows](#windows)
   - [Binary](#binary)
   - [From source](#from-source)
+  - [Use Docker](#use-docker)
 - [Checkpoint Summary](#checkpoint-summary)
 - [Quick Start](#quick-start)
   - [Basic](#basic)
   - [Docker](#docker)
-- [Examples](#examples)
-  - [Scan an image](#scan-an-image)
-  - [Scan an image file](#scan-an-image-file)
-  - [Save the results as JSON](#save-the-results-as-json)
-  - [Specify exit code](#specify-exit-code)
-  - [Ignore the specified checkpoints](#ignore-the-specified-checkpoints)
-  - [Clear image caches](#clear-image-caches)
-- [Continuous Integration](#continuous-integration-ci)
-  - [Travis CI](#travis-ci)
-  - [CircleCI](#circleci)
-  - [Authorization for Private Docker Registry](#authorization-for-private-docker-registry)
-- [Checkpoint Detail](#checkpoint-detail)
-  - [CIS's Docker Image Checkpoints](#docker-image-checkpoints)
-  - [Dockle Checkpoints for Docker](#dockle-checkpoints-for-docker)
-  - [Dockle Checkpoints for Linux](#dockle-checkpoints-for-linux)
+- [Examples](EXAMPLES.md)
+  - Scan an image
+  - Scan an image file
+  - Get or Save the results as JSON
+  - Specify exit code
+  - Ignore the specified checkpoints
+  - Clear image caches
+- [Continuous Integration](EXAMPLES.md#continuous-integration-ci)
+  - Travis CI
+  - CircleCI
+  - Authorization for Private Docker Registry
+- [Checkpoint Details](CHECKPOINT.md)
+  - CIS's Docker Image Checkpoints
+  - Dockle Checkpoints for Docker
+  - Dockle Checkpoints for Linux
 - [Credits](#credits)
 - [Roadmap](#roadmap)
-
 
 # Features
 
@@ -65,13 +65,12 @@ To check your Docker image, only run:
 - Helping build best-practice Dockerfile
 - Simple usage
   - Specify only the image name
-  - See [Quick Start](#quick-start) and [Examples](#examples)
+  - See [Quick Start](#quick-start) and [Examples](EXAMPLES.md)
 - CIS Benchmarks Support
   - High accuracy
 - DevSecOps
   - Suitable for CI such as Travis CI, CircleCI, Jenkins, etc.
-  - See [CI Example](#continuous-integration-ci)
-
+  - See [CI Example](EXAMPLES.md#continuous-integration-ci)
 
 # Comparison
 
@@ -81,37 +80,36 @@ To check your Docker image, only run:
 | How to run | Binary | Binary | ShellScript |
 | Dependency | No | No | Some dependencies |
 | CI Suitable | ✓ | ✓ | x |
-| Purpose |SecurityAudit<br/>DockerfileLint| DockerfileLint | SecurityAudit<br />DockerfileLint |
-| Covered CIS Benchmarks(Docker Image and Build File) | 7 | 3 | 5 |
-
+| Purpose |SecurityAudit<br/>DockerfileLint| DockerfileLint | SecurityAudit<br/>DockerfileLint |
+| Covered CIS Benchmarks (Docker Image and Build File) | 7 | 3 | 5 |
 
 <details>
 <summary>Detail of CIS Benchmark</summary>
 
-|  | [Dockle](https://github.com/goodwithtech/dockle) | [Docker Bench for Security](https://github.com/docker/docker-bench-security) | [Hadolint](https://github.com/hadolint/hadolint) | 
+|  | [Dockle](https://github.com/goodwithtech/dockle) | [Docker Bench for Security](https://github.com/docker/docker-bench-security) | [Hadolint](https://github.com/hadolint/hadolint) |
 |---|:---:|:---:|:---:|
 | 1.  Create a user for the container | ✓ | ✓ | ✓ |
 | 2.  Use trusted base images for containers | - | – | - |
-| 3.  Do not install unnecessary packages in the container | - | - | - | 
-| 4.  Scan and rebuild the images to include security patches | - | - | - | 
+| 3.  Do not install unnecessary packages in the container | - | - | - |
+| 4.  Scan and rebuild the images to include security patches | - | - | - |
 | 5.  Enable Content trust for Docker | ✓ | ✓ | - |
-| 6.  Add HEALTHCHECK instruction to the container image | ✓ | ✓ | - |
-| 7.  Do not use update instructions alone in the Dockerfile | ✓ | ✓ | ✓|
-| 8.  Remove setuid and setgid permissions in the images | ✓ | - | - |
-| 9.  Use COPY instead of ADD in Dockerfile | ✓ | ✓ | ✓|
+| 6.  Add `HEALTHCHECK` instruction to the container image | ✓ | ✓ | - |
+| 7.  Do not use `update` instructions alone in the Dockerfile | ✓ | ✓ | ✓|
+| 8.  Remove `setuid` and `setgid` permissions in the images | ✓ | - | - |
+| 9.  Use `COPY` instead of `ADD` in Dockerfile | ✓ | ✓ | ✓|
 | 10. Do not store secrets in Dockerfiles | ✓ | - | - |
 | 11. Install verified packages only | -  |  - | - |
 | |7|5|3|
 
 All checkpoints [here](#checkpoint-summary)!
-</details>
 
+</details>
 
 # Installation
 
 ## Linuxbrew
 
-You can use [Homebrew](https://docs.brew.sh/Homebrew-on-Linux) on Linux and WSL(Windows Subsystem for Linux).
+You can use [Homebrew](https://docs.brew.sh/Homebrew-on-Linux) on Linux and WSL (Windows Subsystem for Linux).
 
 ```bash
 $ brew install goodwithtech/dockle/dockle
@@ -142,7 +140,7 @@ $ sudo dpkg -i dockle.deb && rm dockle.deb
 
 You can use [Homebrew](https://brew.sh/) on macOS.
 
-```
+```bash
 $ brew install goodwithtech/dockle/dockle
 ```
 
@@ -160,7 +158,7 @@ $ ./dockle.exe [IMAGE_NAME]
 
 ## Binary
 
-You can get the latest version binary from [this page](https://github.com/goodwithtech/dockle/releases/latest).
+You can get the latest version binary from [releases page](https://github.com/goodwithtech/dockle/releases/latest).
 
 Download the archive file for your operating system/architecture. Unpack the archive, and put the binary somewhere in your `$PATH` (on UNIX-y systems, `/usr/local/bin` or the like).
 
@@ -168,11 +166,22 @@ Download the archive file for your operating system/architecture. Unpack the arc
 
 ## From source
 
-```sh
+```bash
 $ go get -u github.com/goodwithtech/dockle
 ```
 
+## Use Docker
+
+There's a [`Dockle` image on Docker Hub](https://hub.docker.com/r/goodwithtech/dockle) also. You can try `dockle` before installing the command.
+
+```
+$ docker pull goodwithtech/dockle:latest
+```
+
 # Quick Start
+
+Here's a quick start. For more detailed usage and samples, such as using `dockle` on CIs, see [EXAMPLES.md](./EXAMPLES.md).
+
 
 ## Basic
 
@@ -214,59 +223,69 @@ FATAL   - Avoid empty password
 PASS    - Be unique UID
 PASS    - Be unique GROUP
 ```
+
 </details>
 
 ## Docker
 
-Replace [YOUR_CACHE_DIR] with the cache directory on your machine.
+Also, you can use Docker to use `dockle` command as follow.
 
+```bash
+$ docker run --rm goodwithtech/dockle [YOUR_IMAGE_NAME]
 ```
+
+For more suitable use, I suggest mounting a cache directory. Replace `[YOUR_CACHE_DIR]` below with the cache directory on your machine.
+
+```bash
 $ docker run --rm -v [YOUR_CACHE_DIR]:/root/.cache/ goodwithtech/dockle [YOUR_IMAGE_NAME]
 ```
 
-Example for macOS:
+- Example for macOS:
 
-```
-$ docker run --rm -v $HOME/Library/Caches:/root/.cache/ goodwithtech/dockle [YOUR_IMAGE_NAME]
-```
+    ```bash
+    $ docker run --rm -v $HOME/Library/Caches:/root/.cache/ goodwithtech/dockle [YOUR_IMAGE_NAME]
+    ```
 
-If you would like to scan the image on your host machine, you need to mount `docker.sock`.
+- If you'd like to scan the image on your host machine, you need to mount `docker.sock`.
 
-```
-$ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock ...
-```
+    ```bash
+    $ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock ...
+    ```
 
-Please, re-pull latest `goodwithtech/dockle` if an error occurs.
+- NOTE: `Dockle` is often updated. Please, re-pull the latest `goodwithtech/dockle` if an error occurs.
+
 
 # Checkpoint Summary
 
+- Details of each checkpoint see [CHECKPOINT.md](CHECKPOINT.md)
+
 | CODE | DESCRIPTION | LEVEL[※](#level) |
 |---|---|:---:|
-| | [CIS's Docker Image Checkpoints](#docker-image-checkpoints) | |
-| [CIS-DI-0001](#cis-di-0001-create-a-user-for-the-container) | Create a user for the container | WARN |
-| [CIS-DI-0002](#cis-di-0002-use-trusted-base-images-for-containers) | Use trusted base images for containers | FATAL
-| [CIS-DI-0003](#cis-di-0003-do-not-install-unnecessary-packages-in-the-container) | Do not install unnecessary packages in the container | FATAL
-| [CIS-DI-0004](#cis-di-0004-scan-and-rebuild-the-images-to-include-security-patches) | Scan and rebuild the images to include security patches | FATAL
-| [CIS-DI-0006](#cis-di-0006-add-healthcheck-instruction-to-the-container-image) | Add HEALTHCHECK instruction to the container image | WARN
-| [CIS-DI-0007](#cis-di-0007-do-not-use-update-instructions-alone-in-the-dockerfile) | Do not use update instructions alone in the Dockerfile | FATAL
-| [CIS-DI-0008](#cis-di-0008-remove-setuid-and-setgid-permissions-in-the-images) | Remove setuid and setgid permissions in the images | INFO
-| [CIS-DI-0009](#cis-di-0009-use-copy-instead-of-add-in-dockerfile) | Use COPY instead of ADD in Dockerfile | FATAL
-| [CIS-DI-0010](#cis-di-0010-do-not-store-secrets-in-dockerfiles) | Do not store secrets in Dockerfiles | FATAL
-| [CIS-DI-0011](#cis-di-0011-install-verified-packages-only) | Install verified packages only | INFO
-|| [Dockle Checkpoints for Docker](#dockle-checkpoints-for-docker) |
-| [DKL-DI-0001](#dkl-di-0001-avoid-sudo-command) | Avoid `sudo` command | FATAL
-| [DKL-DI-0002](#dkl-di-0002-avoid-sensitive-directory-mounting) | Avoid sensitive directory mounting | FATAL
-| [DKL-DI-0003](#dkl-di-0003-avoid-apt-get-upgrade-apk-upgrade-dist-upgrade) | Avoid `apt-get upgrade`, `apk upgrade`, `dist-upgrade` | FATAL
-| [DKL-DI-0004](#dkl-di-0004-use-apk-add-with---no-cache) | Use apk add with `--no-cache` | FATAL
-| [DKL-DI-0005](#dkl-di-0005-clear-apt-get-caches) | Clear apt-get caches | FATAL
-| [DKL-DI-0006](#dkl-di-0006-avoid-latest-tag) | Avoid `latest` tag | WARN
-|| [Dockle Checkpoints for Linux](#dockerdockle-checkpoints-for-linux) |
-| [DKL-LI-0001](#dkl-li-0001-avoid-empty-password) | Avoid empty password | FATAL
-| [DKL-LI-0002](#dkl-li-0002-be-unique-uidgroups) | Be unique UID/GROUPs | FATAL
+| | CIS's Docker Image Checkpoints | |
+| CIS-DI-0001 | Create a user for the container | WARN |
+| CIS-DI-0002 | Use trusted base images for containers | FATAL
+| CIS-DI-0003 | Do not install unnecessary packages in the container | FATAL
+| CIS-DI-0004 | Scan and rebuild the images to include security patches | FATAL
+| CIS-DI-0006 | Add `HEALTHCHECK` instruction to the container image | WARN
+| CIS-DI-0007 | Do not use `update` instructions alone in the Dockerfile | FATAL
+| CIS-DI-0008 | Remove `setuid` and `setgid` permissions in the images | INFO
+| CIS-DI-0009 | Use `COPY` instead of `ADD` in Dockerfile | FATAL
+| CIS-DI-0010 | Do not store secrets in Dockerfiles | FATAL
+| CIS-DI-0011 | Install verified packages only | INFO
+|| Dockle Checkpoints for Docker |
+| DKL-DI-0001 | Avoid `sudo` command | FATAL
+| DKL-DI-0002 | Avoid sensitive directory mounting | FATAL
+| DKL-DI-0003 | Avoid `apt-get upgrade`, `apk upgrade`, `dist-upgrade` | FATAL
+| DKL-DI-0004 | Use `apk add` with `--no-cache` | FATAL
+| DKL-DI-0005 | Clear `apt-get` caches | FATAL
+| DKL-DI-0006 | Avoid `latest` tag | WARN
+|| Dockle Checkpoints for Linux |
+| DKL-LI-0001 | Avoid empty password | FATAL
+| DKL-LI-0002 | Be unique UID/GROUPs | FATAL
 
-#### Level
+## Level
 
-`Dockle` has 5 check levels
+`Dockle` has 5 check levels.
 
 | LEVEL | DESCRIPTION |
 |:---:|---|
@@ -276,495 +295,20 @@ Please, re-pull latest `goodwithtech/dockle` if an error occurs.
 | SKIP | Not found target files |
 | PASS | Not found any problems |
 
-# Examples
-
-## Scan an image
-
-Simply specify an image name (and a tag).
-
-```bash
-$ dockle goodwithtech/test-image:v1
-```
-<details>
-<summary>Result</summary>
-
-```
-FATAL   - CIS-DI-0001: Create a user for the container
-        * Last user should not be root
-WARN    - CIS-DI-0005: Enable Content trust for Docker
-        * export DOCKER_CONTENT_TRUST=1 before docker pull/build
-FATAL   - CIS-DI-0006: Add HEALTHCHECK instruction to the container image
-        * not found HEALTHCHECK statement
-FATAL   - CIS-DI-0007: Do not use update instructions alone in the Dockerfile
-        * Use 'Always combine RUN 'apt-get update' with 'apt-get install' : /bin/sh -c apt-get update && apt-get install -y git
-FATAL   - CIS-DI-0008: Remove setuid and setgid permissions in the images
-        * Found setuid file: etc/passwd grw-r--r--
-        * Found setuid file: usr/lib/openssh/ssh-keysign urwxr-xr-x
-        * Found setuid file: app/hoge.txt ugrw-r--r--
-        * Found setuid file: app/hoge.txt ugrw-r--r--
-        * Found setuid file: etc/shadow urw-r-----
-FATAL   - CIS-DI-0009: Use COPY instead of ADD in Dockerfile
-        * Use COPY : /bin/sh -c #(nop) ADD file:81c0a803075715d1a6b4f75a29f8a01b21cc170cfc1bff6702317d1be2fe71a3 in /app/credentials.json
-FATAL   - CIS-DI-0010: Do not store secrets in ENVIRONMENT variables
-        * Suspicious ENV key found : MYSQL_PASSWD
-FATAL   - CIS-DI-0010: Do not store secret files
-        * Suspicious filename found : app/credentials.json
-PASS    - DKL-DI-0001: Avoid sudo command
-FATAL   - DKL-DI-0002: Avoid sensitive directory mounting
-        * Avoid mounting sensitive dirs : /usr
-PASS    - DKL-DI-0003: Avoid apt-get/apk/dist-upgrade
-PASS    - DKL-DI-0004: Use apk add with --no-cache
-FATAL   - DKL-DI-0005: Clear apt-get caches
-        * Use 'apt-get clean && rm -rf /var/lib/apt/lists/*' : /bin/sh -c apt-get update && apt-get install -y git
-PASS    - DKL-DI-0006: Avoid latest tag
-FATAL   - DKL-LI-0001: Avoid empty password
-        * No password user found! username : nopasswd
-PASS    - DKL-LI-0002: Be unique UID
-PASS    - DKL-LI-0002: Be unique GROUP
-```
-</details>
-
-## Scan an image file
-
-```bash
-$ docker save alpine:latest -o alpine.tar
-$ dockle --input alpine.tar
-```
-
-## Get or Save the results as JSON
-
-```bash
-$ dockle -f json goodwithtech/test-image:v1
-$ dockle -f json -o results.json goodwithtech/test-image:v1
-```
-
-<details>
-<summary>Result</summary>
-
-```json
-{
-  "summary": {
-    "fatal": 6,
-    "warn": 2,
-    "info": 2,
-    "pass": 7
-  },
-  "details": [
-    {
-      "code": "CIS-DI-0001",
-      "title": "Create a user for the container",
-      "level": "WARN",
-      "alerts": [
-        "Last user should not be root"
-      ]
-    },
-    {
-      "code": "CIS-DI-0005",
-      "title": "Enable Content trust for Docker",
-      "level": "INFO",
-      "alerts": [
-        "export DOCKER_CONTENT_TRUST=1 before docker pull/build"
-      ]
-    },
-    {
-      "code": "CIS-DI-0006",
-      "title": "Add HEALTHCHECK instruction to the container image",
-      "level": "WARN",
-      "alerts": [
-        "not found HEALTHCHECK statement"
-      ]
-    },
-    {
-      "code": "CIS-DI-0008",
-      "title": "Remove setuid and setgid permissions in the images",
-      "level": "INFO",
-      "alerts": [
-        "Found setuid file: usr/lib/openssh/ssh-keysign urwxr-xr-x"
-      ]
-    },
-    {
-      "code": "CIS-DI-0009",
-      "title": "Use COPY instead of ADD in Dockerfile",
-      "level": "FATAL",
-      "alerts": [
-        "Use COPY : /bin/sh -c #(nop) ADD file:81c0a803075715d1a6b4f75a29f8a01b21cc170cfc1bff6702317d1be2fe71a3 in /app/credentials.json "
-      ]
-    },
-    {
-      "code": "CIS-DI-0010",
-      "title": "Do not store secrets in ENVIRONMENT variables",
-      "level": "FATAL",
-      "alerts": [
-        "Suspicious ENV key found : MYSQL_PASSWD"
-      ]
-    },
-    {
-      "code": "CIS-DI-0010",
-      "title": "Do not store secret files",
-      "level": "FATAL",
-      "alerts": [
-        "Suspicious filename found : app/credentials.json "
-      ]
-    },
-    {
-      "code": "DKL-DI-0002",
-      "title": "Avoid sensitive directory mounting",
-      "level": "FATAL",
-      "alerts": [
-        "Avoid mounting sensitive dirs : /usr"
-      ]
-    },
-    {
-      "code": "DKL-DI-0005",
-      "title": "Clear apt-get caches",
-      "level": "FATAL",
-      "alerts": [
-        "Use 'rm -rf /var/lib/apt/lists' after 'apt-get install' : /bin/sh -c apt-get update \u0026\u0026 apt-get install -y git"
-      ]
-    },
-    {
-      "code": "DKL-LI-0001",
-      "title": "Avoid empty password",
-      "level": "FATAL",
-      "alerts": [
-        "No password user found! username : nopasswd"
-      ]
-    }
-  ]
-}
-```
-</details>
-
-## Specify exit code
-
-By default, `Dockle` exits with code `0` even if there are some problems.
-
-Use the `--exit-code` option to exit with a non-zero exit code if any alert were found.
-
-```bash
-$ dockle  -exist-code 1 [IMAGE_NAME]
-```
-
-## Ignore the specified checkpoints
-
-Use `.dockleignore`.
-
-```bash
-$ cat .dockleignore
-# set root to default user because we want to run nginx
-CIS-DI-0001
-# Use latest tag because to check only the image inside
-DKL-DI-0006
-```
-
-### Clear image caches
-
-The `--clear-cache` option removes image caches. This option is useful if the image which has the same tag is updated (such as when using `latest` tag).
-
-```
-$ dockle --clear-cache python:3.7
-```
-
-# Continuous Integration (CI)
-
-Scan your image built in Travis CI/CircleCI. 
-The test will fail with if an error is found.
-You can skip target checkpoint if you use `.dockleignore`.
- 
-When you don't would like to fail the test, specify `--exit-code 0`.
-
-
-## Travis CI
-
-```yaml
-services:
-  - docker
-
-env:
-  global:
-    - COMMIT=${TRAVIS_COMMIT::8}
-
-before_install:
-  - docker build -t dockle-ci-test:${COMMIT} .
-  - export VERSION=$(curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-  - wget https://github.com/goodwithtech/dockle/releases/download/v${VERSION}/dockle_${VERSION}_Linux-64bit.tar.gz
-  - tar zxvf dockle_${VERSION}_Linux-64bit.tar.gz
-script:
-  - ./dockle dockle-ci-test:${COMMIT}
-  - ./dockle --exit-code 1 dockle-ci-test:${COMMIT}
-```
-
-- Example: https://travis-ci.org/goodwithtech/dockle-ci-test
-- Repository: https://github.com/goodwithtech/dockle-ci-test
-
-## CircleCI
-
-```yaml
-jobs:
-  build:
-    docker:
-      - image: docker:18.09-git
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Build image
-          command: docker build -t dockle-ci-test:${CIRCLE_SHA1} .
-      - run:
-          name: Install dockle
-          command: |
-            apk add --update curl
-            VERSION=$(
-                curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | \
-                grep '"tag_name":' | \
-                sed -E 's/.*"v([^"]+)".*/\1/'
-            )
-            wget https://github.com/goodwithtech/dockle/releases/download/v${VERSION}/dockle_${VERSION}_Linux-64bit.tar.gz
-            tar zxvf dockle_${VERSION}_Linux-64bit.tar.gz
-            mv dockle /usr/local/bin
-      - run:
-          name: Scan the local image with dockle
-          command: dockle --exit-code 1 dockle-ci-test:${CIRCLE_SHA1}
-workflows:
-  version: 2
-  release:
-    jobs:
-      - build
-```
-
-- Example: https://circleci.com/gh/goodwithtech/dockle-ci-test
-- Repository: https://github.com/goodwithtech/dockle-ci-test
-
-## Authorization for Private Docker Registry
-
-`Dockle` can download images from a private registry, without installing `Docker` and any 3rd party tools.
-That's because it's easy to run in a CI process.
-
-All you have to do is install `Dockle` and set ENVIRONMENT variables.
-But, I can't recommend using ENV vars in your local machine to you.
-
-### Docker Hub
-
-You don't need to set ENV vars as below when downloading from the public repository.
-
-For the private repository, Docker Hub needs `DOCKLE_AUTH_URL`, `DOCKLE_USERNAME` and `DOCKLE_PASSWORD`.
-
-```bash
-export DOCKLE_AUTH_URL=https://registry.hub.docker.com
-export DOCKLE_USERNAME={DOCKERHUB_USERNAME}
-export DOCKLE_PASSWORD={DOCKERHUB_PASSWORD}
-```
-
-### Amazon ECR (Elastic Container Registry)
-
-`Dockle` uses AWS SDK. You don't need to install `aws` CLI tool.
-You can use [AWS CLI's ENVIRONMENT variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
-
-### GCR (Google Container Registry)
-
-`Dockle` uses Google Cloud SDK. So, you don't need to install `gcloud` command.
-
-If you would like to use the target project's repository, you can settle via `GOOGLE_APPLICATION_CREDENTIAL`. 
-
-```bash
-# must set DOCKLE_USERNAME empty char
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credential.json
-```
-
-### Self Hosted Registry (BasicAuth)
-
-BasicAuth server needs `DOCKLE_USERNAME` and `DOCKLE_PASSWORD`.
-
-```bash
-export DOCKLE_USERNAME={USERNAME}
-export DOCKLE_PASSWORD={PASSWORD}
-
-# if you'd like to use 80 port, use NonSSL
-export DOCKLE_NON_SSL=true
-```
-
-# Checkpoint Detail
-
-## Docker Image Checkpoints
-
-These checkpoints refered to [CIS Docker 1.13.0 Benchmark v1.0.0](https://www.cisecurity.org/benchmark/docker/).
-
-### CIS-DI-0001: Create a user for the container
-
-> Create a non-root user for the container in the Dockerfile for the container image.
->
-> It is a good practice to run the container as a non-root user, if possible. 
-
-```
-# Dockerfile
-RUN useradd -d /home/dockle -m -s /bin/bash dockle
-USER dockle
-
-or 
-
-RUN addgroup -S dockle && adduser -S -G dockle dockle
-USER dockle
-
-```
-
-### CIS-DI-0002: Use trusted base images for containers
-
-Dockle checks [Content Trust](https://docs.docker.com/engine/security/trust/content_trust/). 
-Please check with [Trivy](https://github.com/knqyf263/trivy).
-
-### CIS-DI-0003: Do not install unnecessary packages in the container
-
-Not supported.
-
-### CIS-DI-0004: Scan and rebuild the images to include security patches
-
-Not supported.
-Please check with [Trivy](https://github.com/knqyf263/trivy).
-
-### CIS-DI-0005: Enable Content trust for Docker
-
-> Content trust is disabled by default. You should enable it.
-
-```bash
-$ export DOCKER_CONTENT_TRUST=1 
-```
-
-https://docs.docker.com/engine/security/trust/content_trust/#about-docker-content-trust-dct
-> Docker Content Trust (DCT) provides the ability to use digital signatures for data sent to and received from remote Docker registries.
-> Engine Signature Verification prevents the following:
-> - `$ docker container run` of an unsigned image.
-> - `$ docker pull` of an unsigned image.
-> - `$ docker build` where the FROM image is not signed or is not scratch.
-
-### CIS-DI-0006: Add HEALTHCHECK instruction to the container image
-
-> Add `HEALTHCHECK` instruction in your docker container images to perform the health check on running containers.
->
-> Based on the reported health status, the docker engine could then exit non-working containers and instantiate new ones.
-```
-# Dockerfile
-HEALTHCHECK --interval=5m --timeout=3s \
-  CMD curl -f http://localhost/ || exit 1
-```
-
-### CIS-DI-0007: Do not use update instructions alone in the Dockerfile
-
-> Do not use update instructions such as `apt-get update` alone or in a single line in the Dockerfile.
-> 
-> Adding the update instructions in a single line on the Dockerfile will cache the update layer.
-```bash
-RUN apt-get update && apt-get install -y package-a
-```
-
-### CIS-DI-0008: Remove setuid and setgid permissions in the images
-
-> Removing setuid and setgid permissions in the images would prevent privilege escalation attacks in the containers.<br/>
-> setuid and setgid permissions could be used for elevating privileges.
-```bash
-chmod u-s setuid-file
-chmod u-g setgid-file
-```
-
-### CIS-DI-0009: Use COPY instead of ADD in Dockerfile
-
-> Use COPY instruction instead of ADD instruction in the Dockerfile.
->
-> `ADD` instruction introduces risks such as adding malicious files from URLs without scanning and unpacking procedure vulnerabilities.
-```
-# Dockerfile
-ADD test.json /app/test.json
-↓
-COPY test.json /app/test.json
-```
-
-### CIS-DI-0010: Do not store secrets in Dockerfiles
-
-> Do not store any secrets in Dockerfiles.<br/>
-> the secrets within these Dockerfiles could be easily exposed and potentially be exploited.
-
-`Dockle` checks ENVIRONMENT variables and credential files.
-
-### CIS-DI-0011: Install verified packages only
-
-Not supported.
-It's better to use [Trivy](https://github.com/knqyf263/trivy).
-
-## Dockle Checkpoints for Docker
-
-These checkpoints referred to [Docker Best Practice](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) and so on.
-
-### DKL-DI-0001: Avoid `sudo` command
-
-https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
-> Avoid installing or using sudo as it has unpredictable TTY and signal-forwarding behavior that can cause problems.
-
-### DKL-DI-0002: Avoid sensitive directory mounting
-
-A volume mount makes weak points. 
-This depends on mounting volumes.
-Currently, `Dockle` checks following directories.
-
-`/boot`, `/dev`, `/etc`, `/lib`, `/proc`, `/sys`,  `/usr`
-
-`dockle` only checks `VOLUME` statements. We can't check `docker run -v /lib:/lib ...`.
-
-
-### DKL-DI-0003: Avoid `apt-get upgrade`, `apk upgrade`, `dist-upgrade`
-
-https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get
- 
-> Avoid `RUN apt-get upgrade` and `dist-upgrade`, as many of the “essential” packages from the parent images cannot upgrade inside an unprivileged container.
-
-### DKL-DI-0004: Use apk add with `--no-cache`
-
-https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache
-
-> As of Alpine Linux 3.3 there exists a new `--no-cache` option for `apk`. It allows users to install packages with an index that is updated and used on-the-fly and not cached locally:
-> This avoids the need to use `--update` and remove `/var/cache/apk/*` when done installing packages.
-
-### DKL-DI-0005: Clear apt-get caches
-
-Use `apt-get clearn && rm -rf /var/lib/apt/lists/*` after `apt-get install`.
-
-https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get
-> In addition, when you clean up the `apt cache` by removing `/var/lib/apt/lists` it reduces the image size, since the apt cache is not stored in a layer. Since the RUN statement starts with apt-get update, the package cache is always refreshed prior to `apt-get install`.
-
-
-### DKL-DI-0006: Avoid `latest` tag
-
-https://vsupalov.com/docker-latest-tag/
-
-> Docker images tagged with :latest have caused many people a lot of trouble.
-
-## Dockle Checkpoints for Linux
-
-These checkpoints referred to [Linux Best Practices](https://www.cyberciti.biz/tips/linux-security.html) and so on.
-
-### DKL-LI-0001: Avoid empty password 
-
-https://blog.aquasec.com/cve-2019-5021-alpine-docker-image-vulnerability
-
-> CVE-2019-5021: Alpine Docker Image ‘null root password’ Vulnerability
-
-### DKL-LI-0002: Be unique UID/GROUPs
-
-http://www.linfo.org/uid.html
-
-> Contrary to popular belief, it is not necessary that each entry in the UID field be unique. However, non-unique UIDs can cause security problems, and thus UIDs should be kept unique across the entire organization.
-
 # Credits
 
 Special Thanks to [@knqyf263](https://github.com/knqyf263) (Teppei Fukuda) and [Trivy](https://github.com/knqyf263/trivy)
 
 # License
 
-AGPLv3
+- AGPLv3
 
 # Author
 
 [@tomoyamachi](https://github.com/tomoyamachi) (Tomoya Amachi)
 
 # Roadmap
+
 - [x] JSON output
 - [ ] Check php.ini file
 - [ ] Check nginx.conf file
@@ -779,14 +323,13 @@ AGPLv3
   - [ ] Insecure permission
 - Image Size
   - [ ] check large size container
-  
-  
+
 ## if running docker daemon...
+
 - Networking
   - [ ] `docker port container` if docker running
   - [ ] by file
-    - /proc/1/net/tcp : openning port (if running)
+    - `/proc/1/net/tcp` : openning port (if running)
 - Volume mount
-  - mount dangerous 
-    - /boot, /dev, /etc, /lib
-
+  - dangerous mount
+    - `/boot`, `/dev`, `/etc`, `/lib`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/goodwithtech/dockle/master/imgs/logo.png" width="450">
+<img src="imgs/logo.png" width="450">
 
 [![GitHub release](https://img.shields.io/github/release/goodwithtech/dockle.svg)](https://github.com/goodwithtech/dockle/releases/latest)
 [![CircleCI](https://circleci.com/gh/goodwithtech/dockle.svg?style=svg)](https://circleci.com/gh/goodwithtech/dockle)
@@ -20,8 +20,8 @@ $ brew install goodwithtech/dockle/dockle
 $ dockle [YOUR_IMAGE_NAME]
 ```
 
-<img src="https://raw.githubusercontent.com/goodwithtech/dockle/master/imgs/usage_pass_light.png" width="800">
-<img src="https://raw.githubusercontent.com/goodwithtech/dockle/master/imgs/usage_fail_light.png" width="800">
+<img src="imgs/usage_pass_light.png" width="800">
+<img src="imgs/usage_fail_light.png" width="800">
 
 
 # TOC
@@ -273,27 +273,27 @@ $ docker run --rm -v [YOUR_CACHE_DIR]:/root/.cache/ goodwithtech/dockle:${DOCKLE
 
 | CODE | DESCRIPTION | LEVEL[※](#level) |
 |---|---|:---:|
-| | CIS's Docker Image Checkpoints | |
-| CIS-DI-0001 | Create a user for the container | WARN |
-| CIS-DI-0002 | Use trusted base images for containers | FATAL
-| CIS-DI-0003 | Do not install unnecessary packages in the container | FATAL
-| CIS-DI-0004 | Scan and rebuild the images to include security patches | FATAL
-| CIS-DI-0006 | Add `HEALTHCHECK` instruction to the container image | WARN
-| CIS-DI-0007 | Do not use `update` instructions alone in the Dockerfile | FATAL
-| CIS-DI-0008 | Remove `setuid` and `setgid` permissions in the images | INFO
-| CIS-DI-0009 | Use `COPY` instead of `ADD` in Dockerfile | FATAL
-| CIS-DI-0010 | Do not store secrets in Dockerfiles | FATAL
-| CIS-DI-0011 | Install verified packages only | INFO
-|| Dockle Checkpoints for Docker |
-| DKL-DI-0001 | Avoid `sudo` command | FATAL
-| DKL-DI-0002 | Avoid sensitive directory mounting | FATAL
-| DKL-DI-0003 | Avoid `apt-get upgrade`, `apk upgrade`, `dist-upgrade` | FATAL
-| DKL-DI-0004 | Use `apk add` with `--no-cache` | FATAL
-| DKL-DI-0005 | Clear `apt-get` caches | FATAL
-| DKL-DI-0006 | Avoid `latest` tag | WARN
-|| Dockle Checkpoints for Linux |
-| DKL-LI-0001 | Avoid empty password | FATAL
-| DKL-LI-0002 | Be unique UID/GROUPs | FATAL
+| | [CIS's Docker Image Checkpoints](CHECKPOINT.md#docker-image-checkpoints) | |
+| [CIS-DI-0001](CHECKPOINT.md#cis-di-0001-create-a-user-for-the-container) | Create a user for the container | WARN |
+| [CIS-DI-0002](CHECKPOINT.md#cis-di-0002-use-trusted-base-images-for-containers) | Use trusted base images for containers | FATAL
+| [CIS-DI-0003](CHECKPOINT.md#cis-di-0003-do-not-install-unnecessary-packages-in-the-container) | Do not install unnecessary packages in the container | FATAL
+| [CIS-DI-0004](CHECKPOINT.md#cis-di-0004-scan-and-rebuild-the-images-to-include-security-patches) | Scan and rebuild the images to include security patches | FATAL
+| [CIS-DI-0006](CHECKPOINT.md#cis-di-0006-add-healthcheck-instruction-to-the-container-image) | Add `HEALTHCHECK` instruction to the container image | WARN
+| [CIS-DI-0007](CHECKPOINT.md#cis-di-0007-do-not-use-update-instructions-alone-in-the-dockerfile) | Do not use `update` instructions alone in the Dockerfile | FATAL
+| [CIS-DI-0008](CHECKPOINT.md#cis-di-0008-remove-setuid-and-setgid-permissions-in-the-images) | Remove `setuid` and `setgid` permissions in the images | INFO
+| [CIS-DI-0009](CHECKPOINT.md#cis-di-0009-use-copy-instead-of-add-in-dockerfile) | Use `COPY` instead of `ADD` in Dockerfile | FATAL
+| [CIS-DI-0010](CHECKPOINT.md#cis-di-0010-do-not-store-secrets-in-dockerfiles) | Do not store secrets in Dockerfiles | FATAL
+| [CIS-DI-0011](CHECKPOINT.md#cis-di-0011-install-verified-packages-only) | Install verified packages only | INFO
+|| [Dockle Checkpoints for Docker](CHECKPOINT.md#dockle-checkpoints-for-docker) |
+| [DKL-DI-0001](CHECKPOINT.md#dkl-di-0001-avoid-sudo-command) | Avoid `sudo` command | FATAL
+| [DKL-DI-0002](CHECKPOINT.md#dkl-di-0002-avoid-sensitive-directory-mounting) | Avoid sensitive directory mounting | FATAL
+| [DKL-DI-0003](CHECKPOINT.md#dkl-di-0003-avoid-apt-get-upgrade-apk-upgrade-dist-upgrade) | Avoid `apt-get upgrade`, `apk upgrade`, `dist-upgrade` | FATAL
+| [DKL-DI-0004](CHECKPOINT.md#dkl-di-0004-use-apk-add-with---no-cache) | Use `apk add` with `--no-cache` | FATAL
+| [DKL-DI-0005](CHECKPOINT.md#dkl-di-0005-clear-apt-get-caches) | Clear `apt-get` caches | FATAL
+| [DKL-DI-0006](CHECKPOINT.md#dkl-di-0006-avoid-latest-tag) | Avoid `latest` tag | WARN
+|| [Dockle Checkpoints for Linux](CHECKPOINT.md#dockerdockle-checkpoints-for-linux) |
+| [DKL-LI-0001](CHECKPOINT.md#dkl-li-0001-avoid-empty-password) | Avoid empty password | FATAL
+| [DKL-LI-0002](CHECKPOINT.md#dkl-li-0002-be-unique-uidgroups) | Be unique UID/GROUPs | FATAL
 
 ## Level
 
@@ -302,7 +302,7 @@ $ docker run --rm -v [YOUR_CACHE_DIR]:/root/.cache/ goodwithtech/dockle:${DOCKLE
 | LEVEL | DESCRIPTION |
 |:---:|---|
 | FATAL | Be practical and prudent |
-| WARN | Be practical and prudent, but limited uses (official docker image ) |
+| WARN | Be practical and prudent, but limited uses (even if official images) |
 | INFO | May negatively inhibit the utility or performance |
 | SKIP | Not found target files |
 | PASS | Not found any problems |


### PR DESCRIPTION
Here's the first fix of the doc for https://github.com/goodwithtech/dockle/issues/25#issuecomment-502322303.

**I haven't finished** all, like linking the TOC to the external files, but I'll push the branch to be reviewed by others, since **more improvements are needed**. 

So, any additional push is welcome!

- What I did:
  - Spellcheck
  - Fix some Markdown lint alert
  - Split examples, CI usage and checkpoint details to other files
  - Add samples of ENV vars for AWS
  - Add description on "Install" about docker
  - etc.

@tomoyamachi Please wait to merge until I finish link the TOC, and merge when you feel it's good-to-go.
