### PR TITLE
suid: Print file mode left of file name

### DIFF
--- a/pkg/assessor/privilege/suid.go
+++ b/pkg/assessor/privilege/suid.go
@@ -21,7 +21,7 @@ func (a PrivilegeAssessor) Assess(fileMap deckodertypes.FileMap) ([]*types.Asses
 				&types.Assessment{
 					Code:     types.CheckSuidGuid,
 					Filename: filename,
-					Desc:     fmt.Sprintf("setuid file: %s %s", filename, filedata.FileMode),
+					Desc:     fmt.Sprintf("setuid file: %s %s", filedata.FileMode, filename),
 				})
 		}
 		if filedata.FileMode&os.ModeSetgid != 0 {
@@ -30,7 +30,7 @@ func (a PrivilegeAssessor) Assess(fileMap deckodertypes.FileMap) ([]*types.Asses
 				&types.Assessment{
 					Code:     types.CheckSuidGuid,
 					Filename: filename,
-					Desc:     fmt.Sprintf("setgid file: %s %s", filename, filedata.FileMode),
+					Desc:     fmt.Sprintf("setgid file: %s %s", filedata.FileMode, filename),
 				})
 		}
 


### PR DESCRIPTION
The output looks cleaner (file modes are more probably fixed-width)
and is in line with the output of `stat -c '%A %n'` and `ls -l`.