### PR TITLE
install on Linux fails copy & paste from git UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $ brew install goodwithtech/r/dockle
 ## RHEL/CentOS
 
 ```bash
-$ VERSION=$(
+VERSION=$(
  curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | \
  grep '"tag_name":' | \
  sed -E 's/.*"v([^"]+)".*/\1/' \
@@ -109,7 +109,7 @@ $ VERSION=$(
 ## Debian/Ubuntu
 
 ```bash
-$ VERSION=$(
+VERSION=$(
  curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | \
  grep '"tag_name":' | \
  sed -E 's/.*"v([^"]+)".*/\1/' \
@@ -128,7 +128,7 @@ yay -Sy dockle-bin
 ## Windows
 
 ```bash
-$ VERSION=$(
+VERSION=$(
  curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | \
  grep '"tag_name":' | \
  sed -E 's/.*"v([^"]+)".*/\1/' \


### PR DESCRIPTION
ERROR:
 $ VERSION=$(
 curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | \
 grep '"tag_name":' | \
 sed -E 's/.*"v([^"]+)".*/\1/' \
) && rpm -ivh https://github.com/goodwithtech/dockle/releases/download/v${VERSION}/dockle_${VERSION}_Linux-64bit.rpm
**bash: $: command not found...**