### PR TITLE
Fix SARIF label for warn level

### DIFF
--- a/pkg/report/writer.go
+++ b/pkg/report/writer.go
@@ -17,7 +17,7 @@ var AlertLabels = map[int]string{
 }
 var sarifAlertLabels = map[int]string{
 	types.InfoLevel:   "note",
-	types.WarnLevel:   "warn",
+	types.WarnLevel:   "warning",
 	types.FatalLevel:  "error",
 	types.PassLevel:   "none",
 	types.SkipLevel:   "none",


### PR DESCRIPTION
According to the SARIF Standard section 3.27.10, `warning` should be used instead of `warn`