### PR TITLE
Arch Linux: Improve installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,11 @@ VERSION=$(
 $ sudo dpkg -i dockle.deb && rm dockle.deb
 ```
 ## Arch Linux
-dockle-bin can be installed from the Arch User Repository. Examples:
+dockle can be installed from the Arch User Repository using `dockle` or `dockle-bin` package.
 ```
-pikaur -Sy dockle-bin
-```
-or
-```
-yay -Sy dockle-bin
+git clone https://aur.archlinux.org/dockle-bin.git
+cd dockle-bin
+makepkg -sri
 ```
 ## Windows
 


### PR DESCRIPTION
Add dockle package
Improve installation section
AUR helpers are not the correct way and should not be suggested:
Read first line of https://wiki.archlinux.org/title/AUR_helpers