### PR TITLE
Add the option to run Dockle programmatically

### DIFF
--- a/cmd/dockle/main.go
+++ b/cmd/dockle/main.go
@@ -15,10 +15,10 @@ var (
 )
 
 /*
-NewDockleCli Factory for Dockle CLI creation.
+NewApp Factory for Dockle CLI creation.
 An Enabler for programmatic usage of Dockle
 */
-func NewDockleCli() *cli.App {
+func NewApp() *cli.App {
 	cli.AppHelpTemplate = `NAME:
   {{.Name}}{{if .Usage}} - {{.Usage}}{{end}}
 USAGE:
@@ -143,7 +143,7 @@ OPTIONS:
 }
 
 func main() {
-	app := NewDockleCli()
+	app := NewApp()
 	err := app.Run(os.Args)
 
 	if err != nil {

--- a/cmd/dockle/main.go
+++ b/cmd/dockle/main.go
@@ -14,7 +14,11 @@ var (
 	version = "dev"
 )
 
-func main() {
+/*
+NewDockleCli Factory for Dockle CLI creation.
+An Enabler for programmatic usage of Dockle
+*/
+func NewDockleCli() *cli.App {
 	cli.AppHelpTemplate = `NAME:
   {{.Name}}{{if .Usage}} - {{.Usage}}{{end}}
 USAGE:
@@ -135,6 +139,11 @@ OPTIONS:
 	}
 
 	app.Action = pkg.Run
+	return app
+}
+
+func main() {
+	app := NewDockleCli()
 	err := app.Run(os.Args)
 
 	if err != nil {


### PR DESCRIPTION
When consuming Dockle as a go module, there is currently no way of running it easily.
The introduction of a public "Dockle CLI creator" will enable that