### PR TITLE
Add docker tcp certificate path. Issue #175

### DIFF
--- a/cmd/dockle/main.go
+++ b/cmd/dockle/main.go
@@ -147,7 +147,12 @@ OPTIONS:
 			EnvVar: "DOCKLE_NON_SSL",
 			Usage:  "registry connect without ssl",
 		},
-
+		cli.StringFlag{
+			Name:   "cert-path",
+			EnvVar: "DOCKLE_CERT_PATH",
+			Usage:  "docker daemon certificate path",
+			Value:  dockerSockPath,
+		},
 		cli.StringFlag{
 			Name:  "cache-dir",
 			Usage: "cache directory",

--- a/pkg/run.go
+++ b/pkg/run.go
@@ -60,6 +60,7 @@ func Run(c *cli.Context) (err error) {
 		Password:              c.String("password"),
 		InsecureSkipTLSVerify: c.Bool("insecure"),
 		DockerDaemonHost:      c.String("host"),
+		DockerDaemonCertPath:  c.String("cert-path"),
 		SkipPing:              true,
 	}
 	var imageName string


### PR DESCRIPTION
Add a cert-path parameter to allow private docker certs for tcp connections.

https://github.com/goodwithtech/dockle/issues/175