### PR TITLE
fix command of removing setgid permission

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -88,7 +88,7 @@ RUN apt-get update && apt-get install -y package-a
 
 ```bash
 chmod u-s setuid-file
-chmod u-g setgid-file
+chmod g-s setgid-file
 ```
 
 ### CIS-DI-0009


### PR DESCRIPTION
I couldn't find your contribution guide line and I just opened a pull request.
Sorry if I'm doing something wrong.

It's really minor documentation thing, but isn't it `g-s` instead of `u-g` ?

Also, I appreciate your great work!