### PR TITLE
pkg/assessor/manifest: Add sensitive variable names checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/goodwithtech/deckoder v0.0.1
 	github.com/google/go-cmp v0.5.6
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/owenrumney/go-sarif/v2 v2.0.17
 	github.com/urfave/cli v1.22.4
 	go.uber.org/zap v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -494,6 +494,8 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/pkg/app.go
+++ b/pkg/app.go
@@ -2,9 +2,10 @@ package pkg
 
 import (
 	"fmt"
-	"github.com/urfave/cli"
 	"os"
 	"time"
+
+	"github.com/urfave/cli"
 )
 
 var (
@@ -61,6 +62,11 @@ OPTIONS:
 			Name:   "accept-key, ak",
 			EnvVar: "DOCKLE_ACCEPT_KEYS",
 			Usage:  "For CIS-DI-0010. You can add acceptable keywords. e.g) -ak GPG_KEY -ak KEYCLOAK",
+		},
+		cli.StringSliceFlag{
+			Name:   "sensitive-word, sw",
+			EnvVar: "DOCKLE_REJECT_KEYS",
+			Usage:  "For CIS-DI-0010. You can add sensitive keywords to look for. e.g) -ak api_password -sw keys",
 		},
 		cli.StringSliceFlag{
 			Name:   "accept-file, af",

--- a/pkg/assessor/manifest/manifest.go
+++ b/pkg/assessor/manifest/manifest.go
@@ -23,6 +23,7 @@ type ManifestAssessor struct{}
 
 var ConfigFileName = "metadata"
 var (
+	sensitiveWords   = []string{"pass", "passwd", "access", "token", "secret", "key", "api", "password"}
 	sensitiveDirs    = map[string]struct{}{"/sys": {}, "/dev": {}, "/proc": {}}
 	suspiciousEnvKey = []string{"PASSWD", "PASSWORD", "SECRET", "KEY", "ACCESS"}
 	acceptanceEnvKey = map[string]struct{}{"GPG_KEY": {}, "GPG_KEYS": {}}
@@ -43,6 +44,10 @@ func (a ManifestAssessor) Assess(fileMap deckodertypes.FileMap) (assesses []*typ
 	}
 
 	return checkAssessments(d)
+}
+
+func AddSensitiveWords(words []string) {
+	sensitiveWords = append(sensitiveWords, words...)
 }
 
 func AddAcceptanceKeys(keys []string) {
@@ -227,7 +232,6 @@ func sensitiveVars(cmd string) bool {
 		return false
 	}
 
-	sensitiveWords := []string{"pass", "passwd", "access", "token", "secret", "key", "api", "password"}
 	for _, s := range sensitiveWords {
 		sensitiveWords = append(sensitiveWords, strings.ToUpper(s))
 	}

--- a/pkg/assessor/manifest/manifest.go
+++ b/pkg/assessor/manifest/manifest.go
@@ -250,6 +250,10 @@ func sensitiveVars(cmd string) (bool, string) {
 		}
 		varName := strings.Split(word, "=")[0]
 
+		if _, ok := acceptanceEnvKey[varName]; ok {
+			continue
+		}
+
 		if r.MatchString(varName) {
 			return true, varName
 		}

--- a/pkg/assessor/manifest/manifest.go
+++ b/pkg/assessor/manifest/manifest.go
@@ -56,7 +56,7 @@ func AddAcceptanceKeys(keys []string) {
 	}
 }
 
-func setSensitivePatterns() error {
+func compileSensitivePatterns() error {
 	pat := fmt.Sprintf(`.*(?i)%s.*`, strings.Join(suspiciousEnvKey, "|"))
 	r, err := regexp.Compile(pat)
 	if err != nil {
@@ -67,7 +67,7 @@ func setSensitivePatterns() error {
 }
 
 func checkAssessments(img types.Image) (assesses []*types.Assessment, err error) {
-	if err := setSensitivePatterns(); err != nil {
+	if err := compileSensitivePatterns(); err != nil {
 		return nil, err
 	}
 	if img.Config.User == "" || img.Config.User == "root" {

--- a/pkg/assessor/manifest/manifest_test.go
+++ b/pkg/assessor/manifest/manifest_test.go
@@ -402,6 +402,9 @@ func TestAddStatement(t *testing.T) {
 }
 
 func TestSensitiveVars(t *testing.T) {
+	if err := compileSensitivePatterns(); err != nil {
+		t.Fatalf("compile sensitive var patterns: %s", err)
+	}
 	var tests = map[string]struct {
 		cmd      string
 		expected bool

--- a/pkg/assessor/manifest/manifest_test.go
+++ b/pkg/assessor/manifest/manifest_test.go
@@ -401,6 +401,26 @@ func TestAddStatement(t *testing.T) {
 	}
 }
 
+func TestSensitiveVars(t *testing.T) {
+	var tests = map[string]struct {
+		cmd      string
+		expected bool
+	}{
+		"basic":              {cmd: "/bin/sh -c #(nop) ENV PASS=ADMIN", expected: true},
+		"two vars":           {cmd: "/bin/sh -c #(nop) ENV abc=hello password=sensibledata", expected: true},
+		"run command":        {cmd: `/bin/sh -c  SECRET_API_KEY=63AF7AA15067C05616FDDD88A3A2E8F226F0BC06 echo "data"`, expected: true},
+		"run false positive": {cmd: `/bin/sh -c HELLO="PASS=\"notThis\"" echo "false positive"`, expected: false},
+		"run command 2":      {cmd: `/bin/sh -c SECRET=myLittleSecret VAR2=VALUE2 VAR3=VALUE3 echo "Do something"`, expected: true},
+	}
+	for testname, v := range tests {
+		actual := sensitiveVars(v.cmd)
+		if actual != v.expected {
+			t.Errorf("%s want: %t, got %t", testname, v.expected, actual)
+		}
+	}
+
+}
+
 func TestUseDistUpgrade(t *testing.T) {
 	var tests = map[string]struct {
 		cmdSlices map[int][]string

--- a/pkg/assessor/manifest/manifest_test.go
+++ b/pkg/assessor/manifest/manifest_test.go
@@ -407,13 +407,14 @@ func TestSensitiveVars(t *testing.T) {
 		expected bool
 	}{
 		"basic":              {cmd: "/bin/sh -c #(nop) ENV PASS=ADMIN", expected: true},
+		"mixed cases":        {cmd: "/bin/sh -c #(nop) ENV PasS=ADMIN", expected: true},
 		"two vars":           {cmd: "/bin/sh -c #(nop) ENV abc=hello password=sensibledata", expected: true},
 		"run command":        {cmd: `/bin/sh -c  SECRET_API_KEY=63AF7AA15067C05616FDDD88A3A2E8F226F0BC06 echo "data"`, expected: true},
 		"run false positive": {cmd: `/bin/sh -c HELLO="PASS=\"notThis\"" echo "false positive"`, expected: false},
 		"run command 2":      {cmd: `/bin/sh -c SECRET=myLittleSecret VAR2=VALUE2 VAR3=VALUE3 echo "Do something"`, expected: true},
 	}
 	for testname, v := range tests {
-		actual := sensitiveVars(v.cmd)
+		actual, _ := sensitiveVars(v.cmd)
 		if actual != v.expected {
 			t.Errorf("%s want: %t, got %t", testname, v.expected, actual)
 		}

--- a/pkg/run.go
+++ b/pkg/run.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/goodwithtech/dockle/pkg/assessor/manifest"
 	l "log"
 	"os"
 	"strings"
+
+	"github.com/goodwithtech/dockle/pkg/assessor/manifest"
 
 	"github.com/containers/image/v5/transports/alltransports"
 	deckodertypes "github.com/goodwithtech/deckoder/types"
@@ -75,6 +76,7 @@ func Run(c *cli.Context) (err error) {
 			return fmt.Errorf("invalid image: %w", err)
 		}
 	}
+	manifest.AddSensitiveWords(c.StringSlice("sensitive-word"))
 	manifest.AddAcceptanceKeys(c.StringSlice("accept-key"))
 	scanner.AddAcceptanceFiles(c.StringSlice("accept-file"))
 	scanner.AddAcceptanceExtensions(c.StringSlice("accept-file-extension"))


### PR DESCRIPTION
Add check for sensitive variable names in commands history.
Add unit tests.
Add cli flag for adding sensitive keys to look for.