### PR TITLE
Avoid casting the result of fetchLocation

### DIFF
--- a/pkg/utils/fetch.go
+++ b/pkg/utils/fetch.go
@@ -52,5 +52,5 @@ func FetchLatestVersion(ctx context.Context) (version string, err error) {
 	if versionMatched := versionPattern.FindString(*body); versionMatched != "" {
 		return versionMatched, nil
 	}
-	return "", fmt.Errorf("not found version patterns parsing GH response: %s", string(body))
+	return "", fmt.Errorf("not found version patterns parsing GH response: %s", *body)
 }


### PR DESCRIPTION
https://github.com/goodwithtech/dockle/runs/7367330171?check_suite_focus=true

```
Error: pkg/utils/fetch.go:55:84: cannot convert body (type *string) to type string
```

A return value of `fetchLocation` is `*string`. Therefore, I avoid casting it as a `string`.