### PR TITLE
fix: Include artifact locations in SARIF reports

### DIFF
--- a/pkg/report/sarif_test.go
+++ b/pkg/report/sarif_test.go
@@ -1,0 +1,88 @@
+package report
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/goodwithtech/dockle/pkg/types"
+)
+
+func TestSarifWriter_Write(t *testing.T) {
+	tests := []struct {
+		description string
+		assessments types.AssessmentSlice
+		sarif       string
+	}{
+		{
+			description: "Should include location when URI",
+			assessments: types.AssessmentSlice{
+				{
+					Code:     "DKL-DI-0006",
+					Filename: "docker://alpine:latest",
+					Desc:     "Avoid 'latest' tag",
+				},
+			},
+			sarif: "./testdata/DKL-DI-0006.sarif",
+		},
+		{
+			description: "Should include location when file path",
+			assessments: types.AssessmentSlice{
+				{
+					Code:     "CIS-DI-0010",
+					Filename: "/some/abs/path",
+					Desc:     "Suspicious filename found",
+				},
+			},
+			sarif: "./testdata/CIS-DI-0010.sarif",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			// Generate the assessment map
+			am := types.CreateAssessmentMap(
+				tt.assessments,
+				map[string]struct{}{},
+				false,
+			)
+
+			// Write the serif report to a buffer
+			output := &bytes.Buffer{}
+			writer := &SarifWriter{Output: output}
+			_, err := writer.Write(am)
+			if err != nil {
+				t.Errorf("Write error: %v", err)
+			}
+
+			// parse that JSON into a map for easy comparison
+			var actual map[string]interface{}
+			err = json.NewDecoder(output).Decode(&actual)
+			if err != nil {
+				t.Errorf("Decode error: %v", err)
+			}
+
+			expected := loadSarifFixture(t, tt.sarif)
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("diff: %v", diff)
+			}
+		})
+	}
+}
+
+func loadSarifFixture(t testing.TB, path string) map[string]interface{} {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Errorf("Fixture read error: %v", err)
+	}
+
+	var sarif map[string]interface{}
+	err = json.Unmarshal(data, &sarif)
+	if err != nil {
+		t.Errorf("Fixture decode error: %v", err)
+	}
+
+	return sarif
+}

--- a/pkg/report/testdata/CIS-DI-0010.sarif
+++ b/pkg/report/testdata/CIS-DI-0010.sarif
@@ -1,0 +1,43 @@
+{
+    "version": "2.1.0",
+    "$schema": "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+    "runs": [
+        {
+            "tool": {
+                "driver": {
+                    "informationUri": "https://github.com/goodwithtech/dockle",
+                    "name": "Dockle",
+                    "rules": [
+                        {
+                            "id": "CIS-DI-0010",
+                            "name": "CIS-DI-0010",
+                            "shortDescription": {
+                                "text": "Do not store credential in environment variables/files"
+                            },
+                            "helpUri": "https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#CIS-DI-0010"
+                        }
+                    ]
+                }
+            },
+            "results": [
+                {
+                    "ruleId": "CIS-DI-0010",
+                    "ruleIndex": 0,
+                    "level": "error",
+                    "message": {
+                        "text": "Suspicious filename found"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "/some/abs/path"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/pkg/report/testdata/DKL-DI-0006.sarif
+++ b/pkg/report/testdata/DKL-DI-0006.sarif
@@ -1,0 +1,43 @@
+{
+    "version": "2.1.0",
+    "$schema": "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+    "runs": [
+        {
+            "tool": {
+                "driver": {
+                    "informationUri": "https://github.com/goodwithtech/dockle",
+                    "name": "Dockle",
+                    "rules": [
+                        {
+                            "id": "DKL-DI-0006",
+                            "name": "DKL-DI-0006",
+                            "shortDescription": {
+                                "text": "Avoid latest tag"
+                            },
+                            "helpUri": "https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#DKL-DI-0006"
+                        }
+                    ]
+                }
+            },
+            "results": [
+                {
+                    "ruleId": "DKL-DI-0006",
+                    "ruleIndex": 0,
+                    "level": "warning",
+                    "message": {
+                        "text": "Avoid 'latest' tag"
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "docker://alpine:latest"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/pkg/run.go
+++ b/pkg/run.go
@@ -94,7 +94,7 @@ func Run(c *cli.Context) (err error) {
 	if useLatestTag {
 		assessments = append(assessments, &types.Assessment{
 			Code:     types.AvoidLatestTag,
-			Filename: "image tag",
+			Filename: "docker://" + imageName,
 			Desc:     "Avoid 'latest' tag",
 		})
 	}


### PR DESCRIPTION
Fixes #197.

I'm not a SARIF expert, but I followed the info at https://github.com/microsoft/sarif-tutorials and I _think_ this should be correct. I also installed [the SARIF viewer VS Code extension](https://marketplace.visualstudio.com/items?itemName=MS-SarifVSCode.sarif-viewer) and confirmed that the fixture files were showing up as expected:

<img width="1392" alt="Screen Shot 2022-10-23 at 6 24 29 PM" src="https://user-images.githubusercontent.com/245879/197423704-963e3114-0248-427d-bc72-519d781951a7.png">

<img width="1392" alt="Screen Shot 2022-10-23 at 6 25 25 PM" src="https://user-images.githubusercontent.com/245879/197423710-9d71ae5d-3a4e-4599-8455-27e9fdfd577d.png">

Note: the `-` in the line column is because we're not including a line number in the location (I didn't see that data in the `Assessment` struct).

