### PR TITLE
Add Windows release artifacts

### DIFF
--- a/.github/workflows/build-scan-on-push.yml
+++ b/.github/workflows/build-scan-on-push.yml
@@ -5,7 +5,7 @@ jobs:
   build-and-scan:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - run: docker build . -t ${{ github.sha }}
     - uses: Azure/container-scan@v0
       with:

--- a/.github/workflows/releasebuild.yml
+++ b/.github/workflows/releasebuild.yml
@@ -12,10 +12,10 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
           go-version: '1.20'
       - uses: actions/cache@v3.2.2
@@ -29,27 +29,25 @@ jobs:
         env:
           CGO_ENABLED: 0
       - name: Login to docker.io registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login to ghcr.io registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: goodwithtech
           password: ${{ secrets.GH_PAT }}
-      -
-        name: Run GoReleaser
+      - name: Run GoReleaser
         if: success() && startsWith(github.ref, 'refs/tags/v')
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-      -
-        name: Clear
+      - name: Clear
         if: always() && startsWith(github.ref, 'refs/tags/v')
         run: |
           rm -f ${HOME}/.docker/config.json

--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -6,13 +6,14 @@
 These checkpoints referred to [CIS Docker 1.13.0 Benchmark v1.0.0](https://www.cisecurity.org/benchmark/docker/).
 
 ### CIS-DI-0001
+
 **Create a user for the container**
 
 > Create a non-root user for the container in the Dockerfile for the container image.
 >
 > It is a good practice to run the container as a non-root user, if possible.
 
-```
+```Dockerfile
 # Dockerfile
 RUN useradd -d /home/dockle -m -s /bin/bash dockle
 USER dockle
@@ -21,56 +22,61 @@ or
 
 RUN addgroup -S dockle && adduser -S -G dockle dockle
 USER dockle
-
 ```
 
 ### CIS-DI-0002
+
 **Use trusted base images for containers**
 
 Dockle checks [Content Trust](https://docs.docker.com/engine/security/trust/content_trust/).
 
 ### CIS-DI-0003
+
 **Do not install unnecessary packages in the container**
 
 Not supported.
 
 ### CIS-DI-0004
+
 **Scan and rebuild the images to include security patches**
 
 Not supported.
 Please check with [Trivy](https://github.com/knqyf263/trivy).
 
 ### CIS-DI-0005
+
 **Enable Content trust for Docker**
 
 > Content trust is disabled by default. You should enable it.
 
 ```bash
-$ export DOCKER_CONTENT_TRUST=1
+export DOCKER_CONTENT_TRUST=1
 ```
 
-- https://docs.docker.com/engine/security/trust/content_trust/#about-docker-content-trust-dct
+- <https://docs.docker.com/engine/security/trust/content_trust/#about-docker-content-trust-dct>
 
     > Docker Content Trust (DCT) provides the ability to use digital signatures for data sent to and received from remote Docker registries.<br/>
     > Engine Signature Verification prevents the following:
     >
-    >   - `$ docker container run` of an unsigned image.
-    >   - `$ docker pull` of an unsigned image.
-    >   - `$ docker build` where the FROM image is not signed or is not scratch.
+    > - `$ docker container run` of an unsigned image.
+    > - `$ docker pull` of an unsigned image.
+    > - `$ docker build` where the FROM image is not signed or is not scratch.
 
 ### CIS-DI-0006
+
 **Add `HEALTHCHECK` instruction to the container image**
 
 > Add `HEALTHCHECK` instruction in your docker container images to perform the health check on running containers.<br/>
 > Based on the reported health status, the docker engine could then exit non-working containers and instantiate new ones.
 
-```
+```Dockerfile
 # Dockerfile
 HEALTHCHECK --interval=5m --timeout=3s \
   CMD curl -f http://localhost/ || exit 1
 ```
 
 ### CIS-DI-0007
+
 **Do not use `update` instructions alone in the Dockerfile**
 
 > Do not use `update` instructions such as `apt-get update` alone or in a single line in the Dockerfile.<br/>
@@ -81,6 +87,7 @@ RUN apt-get update && apt-get install -y package-a
 ```
 
 ### CIS-DI-0008
+
 **Confirm safety of `setuid` and `setgid` files**
 
 > Removing `setuid` and `setgid` permissions in the images would prevent privilege escalation attacks in the containers.<br/>
@@ -92,12 +99,13 @@ chmod g-s setgid-file
 ```
 
 ### CIS-DI-0009
+
 **Use `COPY` instead of `ADD` in Dockerfile**
 
 > Use `COPY` instruction instead of `ADD` instruction in the Dockerfile.<br/>
 > `ADD` instruction introduces risks such as adding malicious files from URLs without scanning and unpacking procedure vulnerabilities.
 
-```
+```Dockerfile
 # Dockerfile
 ADD test.json /app/test.json
 ↓
@@ -105,6 +113,7 @@ COPY test.json /app/test.json
 ```
 
 ### CIS-DI-0010
+
 **Do not store secrets in Dockerfiles**
 
 > Do not store any secrets in Dockerfiles.<br/>
@@ -113,6 +122,7 @@ COPY test.json /app/test.json
 `Dockle` checks ENVIRONMENT variables and credential files.
 
 ### CIS-DI-0011
+
 **Install verified packages only**
 
 Not supported.
@@ -123,54 +133,59 @@ It's better to use [Trivy](https://github.com/knqyf263/trivy).
 These checkpoints referred to [Docker Best Practice](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) and so on.
 
 ### DKL-DI-0001
+
 **Avoid `sudo` command**
 
-- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
+- <https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user>
 
     > Avoid installing or using sudo as it has unpredictable TTY and signal-forwarding behavior that can cause problems.
 
 ### DKL-DI-0002
+
 **Avoid sensitive directory mounting**
 
 A volume mount makes weak points. This depends on mounting volumes.
 
 Currently, `Dockle` checks following directories:
 
- - `/dev`, `/proc`, `/sys`
+- `/dev`, `/proc`, `/sys`
 
 `dockle` only checks `VOLUME` statements, since we can't check `docker run -v /lib:/lib ...`.
 
-
 ### DKL-DI-0003
+
 **Avoid `apt-get dist-upgrade`**
 
-https://github.com/docker/docker.github.io/pull/12571
+<https://github.com/docker/docker.github.io/pull/12571>
 
-~~https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get~~
+~~<https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get>~~
 ~~Avoid `RUN apt-get upgrade` and `dist-upgrade`, as many of the “essential” packages from the parent images cannot upgrade inside an unprivileged container.~~
 
 ### DKL-DI-0004
+
 **Use `apk add` with `--no-cache`**
 
-- https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache
+- <https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache>
 
     > As of Alpine Linux 3.3 there exists a new `--no-cache` option for `apk`. It allows users to install packages with an index that is updated and used on-the-fly and not cached locally:<br/>
     > ...<br/>
     > This avoids the need to use `--update` and remove `/var/cache/apk/*` when done installing packages.
 
 ### DKL-DI-0005
+
 **Clear `apt-get` caches**
 
 Use `apt-get clean && rm -rf /var/lib/apt/lists/*` after `apt-get install`.
 
-- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get
+- <https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get>
 
     > In addition, when you clean up the `apt cache` by removing `/var/lib/apt/lists` it reduces the image size, since the apt cache is not stored in a layer. Since the `RUN` statement starts with `apt-get update`, the package cache is always refreshed prior to `apt-get install`.
 
 ### DKL-DI-0006
+
 **Avoid `latest` tag**
 
-- https://vsupalov.com/docker-latest-tag/
+- <https://vsupalov.com/docker-latest-tag/>
 
     > Docker images tagged with `:latest` have caused many people a lot of trouble.
 
@@ -179,20 +194,23 @@ Use `apt-get clean && rm -rf /var/lib/apt/lists/*` after `apt-get install`.
 These checkpoints referred to [Linux Best Practices](https://www.cyberciti.biz/tips/linux-security.html) and so on.
 
 ### DKL-LI-0001
+
 **Avoid empty password**
 
-- https://blog.aquasec.com/cve-2019-5021-alpine-docker-image-vulnerability
+- <https://blog.aquasec.com/cve-2019-5021-alpine-docker-image-vulnerability>
 
     > CVE-2019-5021: Alpine Docker Image "null root password" Vulnerability
 
 ### DKL-LI-0002
+
 **Be unique UID/GROUPs**
 
-- http://www.linfo.org/uid.html
+- <http://www.linfo.org/uid.html>
 
     > Contrary to popular belief, it is not necessary that each entry in the UID field be unique. However, non-unique UIDs can cause security problems, and thus UIDs should be kept unique across the entire organization.
 
 ### DKL-LI-0003
+
 **Only put necessary files**
 
 Check `.cache`, `tmp` and so on directories.

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@
     - Checkpoints includes [CIS Benchmarks](https://www.cisecurity.org/cis-benchmarks/)
 
 ```bash
-$ brew untap goodwithtech/dockle # who use 0.1.16 or older version
-$ brew install goodwithtech/r/dockle
-$ dockle [YOUR_IMAGE_NAME]
+brew untap goodwithtech/dockle # who use 0.1.16 or older version
+brew install goodwithtech/r/dockle
+dockle [YOUR_IMAGE_NAME]
 ```
+
 See [Installation](#installation) and [Common Examples](#common-examples)
 
 <img src="imgs/dockle.png" width="800">
@@ -58,13 +59,11 @@ See [Installation](#installation) and [Common Examples](#common-examples)
   - [Travis CI](#travis-ci)
   - [CircleCI](#circleci)
   - [GitLab CI](#gitlab-ci)
-  - [Authorization for Private Docker Registry](#authorization-for-private-docker-registry) 
+  - [Authorization for Private Docker Registry](#authorization-for-private-docker-registry)
 - [Checkpoint Details](CHECKPOINT.md)
   - CIS's Docker Image Checkpoints
   - Dockle Checkpoints for Docker
   - Dockle Checkpoints for Linux
-- [Credits](#credits)
-- [Roadmap](#roadmap)
 
 # Features
 
@@ -86,7 +85,7 @@ See [Installation](#installation) and [Common Examples](#common-examples)
 | Target |  Image | Dockerfile | Host<br/>Docker Daemon<br/>Image<br/>Container Runtime | Image |
 | How to run | Binary | Binary | ShellScript | Binary |
 | Dependency | No | No | Some dependencies | No |
-| CI Suitable | ✓ | ✓ | x | x | 
+| CI Suitable | ✓ | ✓ | x | x |
 | Purpose |Security Audit<br/>Dockerfile Lint| Dockerfile Lint | Security Audit<br/>Dockerfile Lint | Scan Vulnerabilities |
 
 # Installation
@@ -96,7 +95,7 @@ See [Installation](#installation) and [Common Examples](#common-examples)
 You can use Homebrew on [Mac OS X](https://brew.sh/) or [Linux and WSL (Windows Subsystem for Linux)](https://docs.brew.sh/Homebrew-on-Linux).
 
 ```bash
-$ brew install goodwithtech/r/dockle
+brew install goodwithtech/r/dockle
 ```
 
 ## RHEL/CentOS
@@ -119,31 +118,29 @@ VERSION=$(
 ) && curl -L -o dockle.deb https://github.com/goodwithtech/dockle/releases/download/v${VERSION}/dockle_${VERSION}_Linux-64bit.deb
 $ sudo dpkg -i dockle.deb && rm dockle.deb
 ```
+
 ## Arch Linux
+
 dockle can be installed from the Arch User Repository using `dockle` or `dockle-bin` package.
-```
+
+```bash
 git clone https://aur.archlinux.org/dockle-bin.git
 cd dockle-bin
 makepkg -sri
 ```
+
 ## Windows
 
-```bash
-VERSION=$(
- curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | \
- grep '"tag_name":' | \
- sed -E 's/.*"v([^"]+)".*/\1/' \
-) && curl -L -o dockle.zip https://github.com/goodwithtech/dockle/releases/download/v${VERSION}/dockle_${VERSION}_Windows-64bit.zip
-$ unzip dockle.zip && rm dockle.zip
-$ ./dockle.exe [IMAGE_NAME]
-```
-## Microsoft PowerShell 7
-```bash
+### Microsoft PowerShell 7
+
+```powershell
 if (((Invoke-WebRequest "https://api.github.com/repos/goodwithtech/dockle/releases/latest").Content) -match '"tag_name":"v(?<ver>[^"]+)"') {
-$VERSION=$Matches.ver &&
-Invoke-WebRequest "https://github.com/goodwithtech/dockle/releases/download/v${VERSION}/dockle_${VERSION}_Windows-64bit.zip" -OutFile dockle.zip &&
-Expand-Archive dockle.zip && Remove-Item dockle.zip }
+  $VERSION=$Matches.ver
+  Invoke-WebRequest "https://github.com/goodwithtech/dockle/releases/download/v${VERSION}/dockle_${VERSION}_Windows-64bit.zip" -OutFile dockle.zip
+  Expand-Archive dockle.zip && Remove-Item dockle.zip
+}
 ```
+
 ## Binary
 
 You can get the latest version binary from [releases page](https://github.com/goodwithtech/dockle/releases/latest).
@@ -176,16 +173,16 @@ dockle --version
 ## From source
 
 ```bash
-$ GO111MODULE=off go get github.com/goodwithtech/dockle/cmd/dockle
-$ cd $GOPATH/src/github.com/goodwithtech/dockle && GO111MODULE=on go build -o $GOPATH/bin/dockle cmd/dockle/main.go
+GO111MODULE=off go get github.com/goodwithtech/dockle/cmd/dockle
+cd $GOPATH/src/github.com/goodwithtech/dockle && GO111MODULE=on go build -o $GOPATH/bin/dockle cmd/dockle/main.go
 ```
 
 ## Use Docker
 
 There's a [`Dockle` image on Docker Hub](https://hub.docker.com/r/goodwithtech/dockle) also. You can try `dockle` before installing the command.
 
-```
-$ VERSION=$(
+```bash
+VERSION=$(
  curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | \
  grep '"tag_name":' | \
  sed -E 's/.*"v([^"]+)".*/\1/' \
@@ -202,13 +199,13 @@ You only need `-v /var/run/docker.sock:/var/run/docker.sock` when you'd like to 
 Simply specify an image name (and a tag).
 
 ```bash
-$ dockle [YOUR_IMAGE_NAME]
+dockle [YOUR_IMAGE_NAME]
 ```
 
 <details>
 <summary>Result</summary>
 
-```
+```text
 FATAL   - CIS-DI-0009: Use COPY instead of ADD in Dockerfile
         * Use COPY : /bin/sh -c #(nop) ADD file:81c0a803075715d1a6b4f75a29f8a01b21cc170cfc1bff6702317d1be2fe71a3 in /app/credentials.json
 FATAL   - CIS-DI-0010: Do not store credential in ENVIRONMENT vars/files
@@ -241,7 +238,6 @@ INFO    - CIS-DI-0008: Confirm safety of setuid/setgid files
         * setgid file: usr/bin/expiry grwxr-xr-x
         * setuid file: usr/bin/newgrp urwxr-xr-x
 IGNORE  - CIS-DI-0006: Add HEALTHCHECK instruction to the container image
-
 ```
 
 </details>
@@ -251,18 +247,18 @@ IGNORE  - CIS-DI-0006: Add HEALTHCHECK instruction to the container image
 Also, you can use Docker to use `dockle` command as follow.
 
 ```bash
-$ export DOCKLE_LATEST=$(
+export DOCKLE_LATEST=$(
  curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | \
  grep '"tag_name":' | \
  sed -E 's/.*"v([^"]+)".*/\1/' \
 )
-$ docker run --rm goodwithtech/dockle:v${DOCKLE_LATEST} [YOUR_IMAGE_NAME]
+docker run --rm goodwithtech/dockle:v${DOCKLE_LATEST} [YOUR_IMAGE_NAME]
 ```
 
 - If you'd like to scan the image on your host machine, you need to mount `docker.sock`.
 
     ```bash
-    $ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock ...
+    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock ...
     ```
 
 # Checkpoint Summary
@@ -314,13 +310,13 @@ $ docker run --rm goodwithtech/dockle:v${DOCKLE_LATEST} [YOUR_IMAGE_NAME]
 Simply specify an image name (and a tag).
 
 ```bash
-$ dockle goodwithtech/test-image:v1
+dockle goodwithtech/test-image:v1
 ```
 
 <details>
 <summary>Result</summary>
 
-```
+```text
 FATAL   - CIS-DI-0001: Create a user for the container
         * Last user should not be root
 WARN    - CIS-DI-0005: Enable Content trust for Docker
@@ -354,20 +350,21 @@ FATAL   - DKL-LI-0001: Avoid empty password
 PASS    - DKL-LI-0002: Be unique UID
 PASS    - DKL-LI-0002: Be unique GROUP
 ```
+
 </details>
 
 ### Scan an image file
 
 ```bash
-$ docker save alpine:latest -o alpine.tar
-$ dockle --input alpine.tar
+docker save alpine:latest -o alpine.tar
+dockle --input alpine.tar
 ```
 
 ### Get or Save the results as JSON
 
 ```bash
-$ dockle -f json goodwithtech/test-image:v1
-$ dockle -f json -o results.json goodwithtech/test-image:v1
+dockle -f json goodwithtech/test-image:v1
+dockle -f json -o results.json goodwithtech/test-image:v1
 ```
 
 <details>
@@ -471,8 +468,8 @@ $ dockle -f json -o results.json goodwithtech/test-image:v1
 ### Get or Save the results as SARIF
 
 ```bash
-$ dockle -f sarif goodwithtech/test-image:v1
-$ dockle -f sarif -o results.json goodwithtech/test-image:v1
+dockle -f sarif goodwithtech/test-image:v1
+dockle -f sarif -o results.json goodwithtech/test-image:v1
 ```
 
 <details>
@@ -626,6 +623,7 @@ $ dockle -f sarif -o results.json goodwithtech/test-image:v1
   ]
 }
 ```
+
 </details>
 
 ### Specify exit code
@@ -635,7 +633,7 @@ By default, `Dockle` exits with code `0` even if there are some problems.
 Use the `--exit-code, -c` option to exit with a non-zero exit code if `WARN` or `FATAL` alert were found.
 
 ```bash
-$ dockle --exit-code 1 [IMAGE_NAME]
+dockle --exit-code 1 [IMAGE_NAME]
 ```
 
 ### Specify exit level
@@ -645,8 +643,8 @@ By default, `--exit-code` run when there are `WARN` or `FATAL` level alerts.
 Use the `--exit-level, -l` option to change alert level. You can set `info`, `warn` or `fatal`.
 
 ```bash
-$ dockle --exit-code 1 --exit-level info [IMAGE_NAME]
-$ dockle --exit-code 1 --exit-level fatal [IMAGE_NAME]
+dockle --exit-code 1 --exit-level info [IMAGE_NAME]
+dockle --exit-code 1 --exit-level fatal [IMAGE_NAME]
 ```
 
 ### Ignore the specified checkpoints
@@ -654,12 +652,12 @@ $ dockle --exit-code 1 --exit-level fatal [IMAGE_NAME]
 The `--ignore, -i` option can ignore specified checkpoints.
 
 ```bash
-$ dockle -i CIS-DI-0001 -i DKL-DI-0006 [IMAGE_NAME]
+dockle -i CIS-DI-0001 -i DKL-DI-0006 [IMAGE_NAME]
 ```
 
 Or, use `DOCKLE_IGNORES`:
 
-```
+```bash
 export DOCKLE_IGNORES=CIS-DI-0001,DKL-DI-0006
 dockle [IMAGE_NAME]
 ```
@@ -714,7 +712,6 @@ We provide [goodwithtech/dockle-action](https://github.com/goodwithtech/dockle-a
     ignore: 'CIS-DI-0001,DKL-DI-0006'
 ```
 
-
 ### Travis CI
 
 <details>
@@ -737,10 +734,11 @@ script:
   - ./dockle dockle-ci-test:${COMMIT}
   - ./dockle --exit-code 1 dockle-ci-test:${COMMIT}
 ```
+
 </details>
 
-- Example: https://travis-ci.org/goodwithtech/dockle-ci-test
-- Repository: https://github.com/goodwithtech/dockle-ci-test
+- Example: <https://travis-ci.org/goodwithtech/dockle-ci-test>
+- Repository: <https://github.com/goodwithtech/dockle-ci-test>
 
 ### CircleCI
 
@@ -779,10 +777,11 @@ workflows:
     jobs:
       - build
 ```
+
 </details>
 
-- Example: https://circleci.com/gh/goodwithtech/dockle-ci-test
-- Repository: https://github.com/goodwithtech/dockle-ci-test
+- Example: <https://circleci.com/gh/goodwithtech/dockle-ci-test>
+- Repository: <https://github.com/goodwithtech/dockle-ci-test>
 
 ## GitLab CI
 
@@ -815,10 +814,11 @@ unit_test:
       tar zxvf dockle.tar.gz
     - ./dockle --exit-code 1 dockle-ci-test:${CI_COMMIT_SHORT_SHA}
 ```
+
 </details>
 
-- Example: https://gitlab.com/tomoyamachi/dockle-ci-test/-/jobs/238215077
-- Repository: https://github.com/goodwithtech/dockle-ci-test
+- Example: <https://gitlab.com/tomoyamachi/dockle-ci-test/-/jobs/238215077>
+- Repository: <https://github.com/goodwithtech/dockle-ci-test>
 
 ## Authorization for Private Docker Registry
 
@@ -831,7 +831,6 @@ All you have to do is: install `Dockle` and set ENVIRONMENT variables.
 ### Docker Hub
 
 To download the private repository from Docker Hub, you need to set `DOCKLE_AUTH_URL`, `DOCKLE_USERNAME` and `DOCKLE_PASSWORD` ENV vars.
-
 
 ```bash
 export DOCKLE_AUTH_URL=https://registry.hub.docker.com
@@ -909,7 +908,6 @@ Support this project with your organization. Your logo will show up here with a 
 # License
 
 - Apache License 2.0
-
 
 # Author
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ makepkg -sri
 
 ## Windows
 
+### Bash
+
+```bash
+VERSION=$(
+ curl --silent "https://api.github.com/repos/goodwithtech/dockle/releases/latest" | \
+ grep '"tag_name":' | \
+ sed -E 's/.*"v([^"]+)".*/\1/' \
+) && curl -L -o dockle.zip https://github.com/goodwithtech/dockle/releases/download/v${VERSION}/dockle_${VERSION}_Windows-64bit.zip
+unzip dockle.zip && rm dockle.zip
+./dockle.exe [IMAGE_NAME]
+```
+
 ### Microsoft PowerShell 7
 
 ```powershell

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -56,6 +56,7 @@ archives:
       {{- else if eq .Os "netbsd" }}NetBSD
       {{- else if eq .Os "freebsd" }}FreeBSD
       {{- else if eq .Os "dragonfly" }}DragonFlyBSD
+      {{- else if eq .Os "windows" }}Windows
       {{- else}}{{- .Os }}{{ end }}-
       {{- if eq .Arch "amd64" }}64bit
       {{- else if eq .Arch "arm" }}ARM

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -11,6 +11,7 @@ builds:
   goos:
   - darwin
   - linux
+  - windows
   goarch:
   - amd64
   - 386
@@ -20,8 +21,7 @@ builds:
   - 7
 
 nfpms:
-  -
-    formats:
+  - formats:
       - apk
       - deb
       - rpm
@@ -44,8 +44,7 @@ nfpms:
       {{- else }}{{ .Arch }}{{ end }}
 
 archives:
-  -
-    format: tar.gz
+  - format: tar.gz
     format_overrides:
     - goos: windows
       format: zip
@@ -67,8 +66,7 @@ archives:
     - LICENSE
 
 brews:
-  -
-    tap:
+  - repository:
       owner: goodwithtech
       name: homebrew-r
     folder: Formula


### PR DESCRIPTION
Hi,
I just noticed that while there are instructions for the installation of `dockle` on Windows in [`README.md`](https://github.com/goodwithtech/dockle/blob/e8d60f47c5029808aa10dfd6cbaf92646cf69ea7/README.md?plain=1#L129-L146) the required release artifacts seem to be **missing**.

I added the required changes to the `goreleaser.yaml` config file and successfully tested them locally.

I also applied [`markdownlint`](https://github.com/markdownlint/markdownlint) findings on the `README.md` and `CHECKPOINT.md` files to ease readability and fix a few typos.

Afterwards I upgraded the outdated versions of the GitHub Actions used in this project. Please also note that [`Azure/container-scan`](https://github.com/Azure/container-scan) is [**no longer actively maintained**](https://github.com/Azure/container-scan/blob/99cfdbc2165777480795657ffb45ba4c26609109/README.md?plain=1#L3-L11).
