### PR TITLE
Add .env file to suspicious files list

### DIFF
--- a/pkg/assessor/credential/credential.go
+++ b/pkg/assessor/credential/credential.go
@@ -76,6 +76,7 @@ func (a CredentialAssessor) RequiredFiles() []string {
 		"settings.py",
 		"database.yml",
 		"credentials.xml",
+		".env",
 	}
 }
 


### PR DESCRIPTION
Add `.env` file to to suspicious files list.

`.env` file usually contains credentials, tokens, api keys, private keys, etc so it should be considered as a suspicious file if found stored inside a built container image.

Related to #265 