### PR TITLE
Add parameters for sensitive files and sensitive file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,22 @@ dockle -ae pem -ae log [IMAGE_NAME]
 or DOCKLE_ACCEPT_FILE_EXTENSIONS=pem,log dockle [IMAGE_NAME]
 ```
 
+### Reject suspicious `environment variables` / `files` / `file extensions`
+
+```bash
+# --sensitive-word value, --sw value             You can add acceptable keywords.
+dockle -sw PRIVATE [IMAGE_NAME]
+or DOCKLE_ACCEPT_KEYS=GPG_KEY,KEYCLOAK_VERSION dockle [IMAGE_NAME]
+
+# --sensitive-file value, --sf value            You can add acceptable file names.
+dockle -sf .env [IMAGE_NAME]
+or DOCKLE_REJECT_FILES=.env dockle [IMAGE_NAME]
+
+# --sensitive-file-extension value, --se value  You can add acceptable file extensions.
+dockle -se pfx [IMAGE_NAME]
+or DOCKLE_REJECT_FILE_EXTENSIONS=pfx dockle [IMAGE_NAME]
+```
+
 ## Continuous Integration (CI)
 
 You can scan your built image with `Dockle` in Travis CI/CircleCI.

--- a/pkg/app.go
+++ b/pkg/app.go
@@ -65,9 +65,19 @@ OPTIONS:
 			Usage:  "For CIS-DI-0010. You can add acceptable file names. e.g) -af id_rsa -af config.json",
 		},
 		cli.StringSliceFlag{
+			Name:   "sensitive-file, sf",
+			EnvVar: "DOCKLE_REJECT_FILES",
+			Usage:  "For CIS-DI-0010. You can add sensitive files to look for. e.g) -sf .git",
+		},
+		cli.StringSliceFlag{
 			Name:   "accept-file-extension, ae",
 			EnvVar: "DOCKLE_ACCEPT_FILE_EXTENSIONS",
 			Usage:  "For CIS-DI-0010. You can add acceptable file extensions. e.g) -ae pem -ae log",
+		},
+		cli.StringSliceFlag{
+			Name:   "sensitive-file-extension, se",
+			EnvVar: "DOCKLE_REJECT_FILE_EXTENSIONS",
+			Usage:  "For CIS-DI-0010. You can add sensitive files to look for. e.g) -se .pfx",
 		},
 		cli.StringFlag{
 			Name:   "format, f",

--- a/pkg/assessor/credential/credential.go
+++ b/pkg/assessor/credential/credential.go
@@ -13,7 +13,20 @@ import (
 	"github.com/goodwithtech/dockle/pkg/types"
 )
 
+var (
+	suspiciousFiles          []string
+	suspiciousFileExtensions []string
+)
+
 type CredentialAssessor struct{}
+
+func AddSensitiveFiles(files []string) {
+	suspiciousFiles = append(suspiciousFiles, files...)
+}
+
+func AddSensitiveFileExtensions(fileExtensions []string) {
+	suspiciousFileExtensions = append(suspiciousFileExtensions, fileExtensions...)
+}
 
 func (a CredentialAssessor) Assess(fileMap deckodertypes.FileMap) ([]*types.Assessment, error) {
 	log.Logger.Debug("Start scan : credential files")
@@ -58,7 +71,7 @@ func makeMaps(keys []string) map[string]struct{} {
 }
 
 func (a CredentialAssessor) RequiredFiles() []string {
-	return []string{
+	return append([]string{
 		"credentials.json",
 		"credential.json",
 		// TODO: Only check .docker/config.json
@@ -76,11 +89,12 @@ func (a CredentialAssessor) RequiredFiles() []string {
 		"settings.py",
 		"database.yml",
 		"credentials.xml",
-	}
+		//".env",
+	}, suspiciousFiles...)
 }
 
 func (a CredentialAssessor) RequiredExtensions() []string {
-	return []string{
+	return append([]string{
 		// reference: https://github.com/eth0izzle/shhgit/blob/master/config.yaml
 		// TODO: potential sensitive data but they have many false-positives.
 		//       Dockle need to analyze each file.
@@ -107,7 +121,7 @@ func (a CredentialAssessor) RequiredExtensions() []string {
 		".keychain",
 		".pcap",
 		".gnucache",
-	}
+	}, suspiciousFileExtensions...)
 }
 
 func (a CredentialAssessor) RequiredPermissions() []os.FileMode {

--- a/pkg/run.go
+++ b/pkg/run.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/goodwithtech/dockle/pkg/assessor/credential"
 	"github.com/goodwithtech/dockle/pkg/assessor/manifest"
 
 	"github.com/containers/image/v5/transports/alltransports"
@@ -81,7 +82,9 @@ func Run(c *cli.Context) (err error) {
 	}
 	manifest.AddSensitiveWords(c.StringSlice("sensitive-word"))
 	manifest.AddAcceptanceKeys(c.StringSlice("accept-key"))
+	credential.AddSensitiveFiles(c.StringSlice("sensitive-file"))
 	scanner.AddAcceptanceFiles(c.StringSlice("accept-file"))
+	credential.AddSensitiveFileExtensions(c.StringSlice("sensitive-file-extension"))
 	scanner.AddAcceptanceExtensions(c.StringSlice("accept-file-extension"))
 	log.Logger.Debug("Start assessments...")
 	assessments, err := scanner.ScanImage(ctx, imageName, filePath, dockerOption)


### PR DESCRIPTION
Added new parameters for suspicious files or file extensions for checkpoint `CIS-DI-0010`:
- `--sensitive-file` / `--sf` / `DOCKLE_REJECT_FILES` - Add suspicious files to look for
- `--sensitive-file-extension` / `--se` / `DOCKLE_REJECT_FILE_EXTENSIONS` - Add suspicious file extensions to look for

Also updated README.md with documentation regarding already existing `--sensitive-word`

Fixes #265