### PR TITLE
Censor suspicious environment variables

### DIFF
--- a/pkg/assessor/manifest/manifest_test.go
+++ b/pkg/assessor/manifest/manifest_test.go
@@ -459,7 +459,7 @@ func TestSensitiveVars(t *testing.T) {
 		//"skip echo string": {cmd: `/bin/sh -c echo 'secret=foo;' > test.conf`, expected: true},
 	}
 	for testname, v := range tests {
-		actual, _ := sensitiveVars(v.cmd)
+		actual, _, _ := sensitiveVars(v.cmd)
 		if actual != v.expected {
 			t.Errorf("%s want: %t, got %t", testname, v.expected, actual)
 		}


### PR DESCRIPTION
This pull request intends to censor suspicious found environment variables.

Previously any suspicious environment variable found was being leaked during `CIS-DI-0010` checkpoint assessment as seen below:

```
FATAL   - CIS-DI-0010: Do not store credential in environment variables/files
        * Suspicious ENV key found : GITLAB_TOKEN on /bin/sh -c #(nop)  ENV GITLAB_TOKEN=y5V1xiW5eTwq34jasRqFBD (You can suppress it with --accept-key)
```

With this PR the same finding would be:

```
FATAL   - CIS-DI-0010: Do not store credential in environment variables/files
        * Suspicious ENV key found : GITLAB_TOKEN on /bin/sh -c #(nop)  ENV GITLAB_TOKEN=******* (You can suppress it with --accept-key)
```

Notice that the environment variable now isn't leaked on the output to stdout. This also applies to any other export format.

This is important since Dockle might inadvertently leak production (or other environment) credentials on a CI/CD pipeline