### PR TITLE
Fix Multiple Files with Incorrect License Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Financial Contributors on Open Collective](https://opencollective.com/dockle/all/badge.svg?label=financial+contributors)](https://opencollective.com/dockle) [![GitHub release](https://img.shields.io/github/release/goodwithtech/dockle.svg)](https://github.com/goodwithtech/dockle/releases/latest)
 [![CircleCI](https://circleci.com/gh/goodwithtech/dockle.svg?style=svg)](https://circleci.com/gh/goodwithtech/dockle)
 [![Go Report Card](https://goreportcard.com/badge/github.com/goodwithtech/dockle)](https://goreportcard.com/report/github.com/goodwithtech/dockle)
-[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 > Dockle - Container Image Linter for Security, Helping build the Best-Practice Docker Image, Easy to start
 

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -31,7 +31,7 @@ nfpms:
     homepage: "https://github.com/goodwithtech"
     maintainer: "Tomoya Amachi <tomoya.amachi@gmail.com>"
     description: "A Security and Dockerfile checker for Containers"
-    license: "AGPL"
+    license: "Apache 2.0"
     file_name_template: >-
       {{ .ProjectName }}_{{ .Version }}_
       {{- if eq .Os "darwin" }}macOS


### PR DESCRIPTION
Hello dockle team,

- Updated the README to change the license badge from `AGPL` to `Apache 2.0`
- Updated the `nfpm` configurations in `goreleaser` to the `Apache 2.0` license. 

To ensure consistency between the documentation the project's actual license. Please review to confirm accuracy.
Best regards!