### PR TITLE
doc : Better Copy/paste experience with brew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ See [Installation](#installation) and [Common Examples](#common-examples)
 You can use Homebrew on [Mac OS X](https://brew.sh/) or [Linux and WSL (Windows Subsystem for Linux)](https://docs.brew.sh/Homebrew-on-Linux).
 
 ```bash
-$ brew install goodwithtech/r/dockle
+brew install goodwithtech/r/dockle
 ```
 
 ## RHEL/CentOS


### PR DESCRIPTION
Actually, when we copy/paste (clicking the small icon) the `brew` install command we get this : 

```sh
$ brew install goodwithtech/r/dockle
```

whch leads to : 

<img width="490" height="77" alt="image" src="https://github.com/user-attachments/assets/d2758cb2-b25c-450d-9c40-07237112c4f5" />

This PR fixes this for an even smoother install.


:point_right: Thanks a lot for your great tool, I love it :star_struck: 