### PR TITLE
bugfix: DKL-DI-0005 false positive #282

### DIFF
--- a/pkg/assessor/manifest/manifest.go
+++ b/pkg/assessor/manifest/manifest.go
@@ -354,7 +354,7 @@ func reducableAptGetInstall(cmdSlices map[int][]string) bool {
 			useAptLibrary = true
 		}
 		// remove cache must be run after apt library directory changed
-		if useAptLibrary && containsThreshold(cmdSlice, removeAptLibCmds, 3) {
+		if useAptLibrary && (containsThreshold(cmdSlice, removeAptLibCmds, 3) || checkAptCommand(cmdSlice, "dist-clean") || checkAptCommand(cmdSlice, "distclean")) {
 			return false
 		}
 	}


### PR DESCRIPTION
When using `apt`, look for `distclean/dist-clean` as well, see #282.