### PR TITLE
ci: add Dependabot config and govulncheck workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -23,17 +23,47 @@ jobs:
           go-version-file: go.mod
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
-      - name: Run govulncheck
-        # Known accepted findings (as of 2026-07): govulncheck reports 5
-        # vulnerabilities from github.com/docker/docker@v28.5.2+incompatible
-        # (GO-2026-5746, GO-2026-5668, GO-2026-5617, GO-2026-4887,
-        # GO-2026-4883). All are daemon-side issues with "Fixed in: N/A"
-        # because the moby v29 module split means no fixed version exists on
-        # the old module path. Since plain govulncheck cannot suppress
-        # individual findings, this step uses continue-on-error so CI stays
-        # green while the full report (including any NEW vulnerabilities)
-        # remains visible in the job log and as a step warning.
-        # Once the docker/docker dependency migrates to the new module path,
-        # remove continue-on-error to make this step blocking again.
-        continue-on-error: true
-        run: govulncheck ./...
+      - name: Run govulncheck and fail on non-allowlisted findings
+        # govulncheck has no built-in per-finding suppression, so this step
+        # runs it in -json mode and compares the OSV IDs that actually affect
+        # this module (findings with a non-empty call/import trace) against an
+        # explicit allowlist. Any finding outside the allowlist fails the job,
+        # so newly published vulnerabilities are caught immediately.
+        #
+        # Allowlisted findings (as of 2026-07): 5 vulnerabilities from
+        # github.com/docker/docker@v28.5.2+incompatible. All are daemon-side
+        # issues with "Fixed in: N/A" because the moby v29 module split means
+        # no fixed version exists on the old module path. Remove these entries
+        # once containers/image and this repository migrate to the moby v29
+        # module split.
+        run: |
+          printf '%s\n' \
+            GO-2026-4883 \
+            GO-2026-4887 \
+            GO-2026-5617 \
+            GO-2026-5668 \
+            GO-2026-5746 \
+            | sort > allowlist.txt
+
+          # -json mode exits 0 even when findings exist, so a non-zero exit
+          # here means govulncheck itself failed.
+          govulncheck -json ./... > govulncheck.json
+
+          jq -r 'select(.finding != null and (.finding.trace | length) > 0) | .finding.osv' govulncheck.json \
+            | sort -u > found.txt
+
+          echo "Vulnerabilities affecting this module:"
+          cat found.txt
+
+          stale=$(comm -13 found.txt allowlist.txt)
+          if [ -n "$stale" ]; then
+            echo "::warning::Allowlisted vulnerabilities no longer reported (remove from allowlist): ${stale//$'\n'/, }"
+          fi
+
+          new=$(comm -23 found.txt allowlist.txt)
+          if [ -n "$new" ]; then
+            echo "::error::New vulnerabilities not in the allowlist: ${new//$'\n'/, }"
+            echo "Details: https://pkg.go.dev/vuln/<ID> — or run 'govulncheck ./...' locally."
+            exit 1
+          fi
+          echo "OK: only allowlisted findings are present."

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -36,6 +36,11 @@ jobs:
         # no fixed version exists on the old module path. Remove these entries
         # once containers/image and this repository migrate to the moby v29
         # module split.
+        env:
+          # Match the test workflow: with cgo enabled, loading the
+          # containers/storage btrfs driver fails on runners without the
+          # btrfs headers installed.
+          CGO_ENABLED: "0"
         run: |
           printf '%s\n' \
             GO-2026-4883 \

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,39 @@
+name: govulncheck
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    # Weekly on Monday morning (UTC) so new vulnerabilities are caught
+    # even when there is no PR/push activity.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck
+        # Known accepted findings (as of 2026-07): govulncheck reports 5
+        # vulnerabilities from github.com/docker/docker@v28.5.2+incompatible
+        # (GO-2026-5746, GO-2026-5668, GO-2026-5617, GO-2026-4887,
+        # GO-2026-4883). All are daemon-side issues with "Fixed in: N/A"
+        # because the moby v29 module split means no fixed version exists on
+        # the old module path. Since plain govulncheck cannot suppress
+        # individual findings, this step uses continue-on-error so CI stays
+        # green while the full report (including any NEW vulnerabilities)
+        # remains visible in the job log and as a step warning.
+        # Once the docker/docker dependency migrates to the new module path,
+        # remove continue-on-error to make this step blocking again.
+        continue-on-error: true
+        run: govulncheck ./...


### PR DESCRIPTION
## Motivation

Until recently, 21 known vulnerabilities had accumulated in this repository's dependencies without anyone noticing (resolved in #300 and #301). Nothing in CI was watching for outdated dependencies or newly published vulnerabilities, so the same drift would happen again. This PR adds weekly automation for both.

## What was added

- **`.github/dependabot.yml`** — weekly Dependabot updates for:
  - Go modules (`gomod`, root directory)
  - GitHub Actions (`github-actions`, root directory)
- **`.github/workflows/govulncheck.yml`** — runs govulncheck on every pull request, on pushes to `master`, and on a weekly schedule (Monday 06:00 UTC) so new vulnerability database entries are caught even without repo activity. Third-party actions are pinned to full commit SHAs with version comments, following the existing convention in `build-scan-on-push.yml`. Go is set up from `go.mod` via `actions/setup-go` with `go-version-file`.

## Handling of the known docker/docker findings

Running `govulncheck ./...` on current `master` reports exactly 5 vulnerabilities, all in `github.com/docker/docker@v28.5.2+incompatible` and all marked `Fixed in: N/A`:

- GO-2026-5746
- GO-2026-5668
- GO-2026-5617
- GO-2026-4887
- GO-2026-4883

These are daemon-side issues, and no fixed version exists on the old module path because moby v29 split the module. Since plain `govulncheck` has no per-finding suppression mechanism, the workflow implements an **explicit allowlist** instead of silencing failures:

1. `govulncheck -json ./...` produces a JSON stream of findings.
2. A `jq` filter extracts the OSV IDs that actually affect this module (findings with a non-empty call/import trace).
3. The resulting set is compared against the allowlist of the 5 IDs above, maintained directly in the workflow file.
4. **Any finding outside the allowlist fails the job**, so newly published vulnerabilities block CI immediately instead of accumulating unnoticed.
5. Allowlisted IDs that are no longer reported emit a warning, so stale entries get pruned.

The allowlist entries should be removed once containers/image and this repository migrate to the moby v29 module split.

The step runs with `CGO_ENABLED=0` (matching the test workflow): with cgo enabled, package loading fails on ubuntu-latest because the containers/storage btrfs driver needs btrfs headers. The finding set is identical either way (verified locally with `GOOS=linux CGO_ENABLED=0`).

Verified locally: the exact workflow script passes with the current 5 findings, fails (exit 1) when a simulated new OSV ID appears in the findings, and fails when an ID is removed from the allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
