### PR TITLE
refactor: replace golang.org/x/xerrors with standard library errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli v1.22.17
 	go.uber.org/zap v1.28.0
-	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -365,8 +365,6 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da h1:noIWHXmPHxILtqtCOPIhSt0ABwskkZKjD3bXGnZGpNY=
-golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 google.golang.org/api v0.274.0 h1:aYhycS5QQCwxHLwfEHRRLf9yNsfvp1JadKKWBE54RFA=
 google.golang.org/api v0.274.0/go.mod h1:JbAt7mF+XVmWu6xNP8/+CTiGH30ofmCmk9nM8d8fHew=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/pkg/deckoder/analyzer/analyzer.go
+++ b/pkg/deckoder/analyzer/analyzer.go
@@ -2,9 +2,10 @@ package analyzer
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	digest "github.com/opencontainers/go-digest"
-	"golang.org/x/xerrors"
 
 	"github.com/goodwithtech/dockle/pkg/deckoder/extractor"
 	"github.com/goodwithtech/dockle/pkg/deckoder/extractor/docker"
@@ -15,11 +16,11 @@ var (
 	additionalFiles []string
 
 	// ErrUnknownOS occurs when unknown OS is analyzed.
-	ErrUnknownOS = xerrors.New("unknown OS")
+	ErrUnknownOS = errors.New("unknown OS")
 	// ErrPkgAnalysis occurs when the analysis of packages is failed.
-	ErrPkgAnalysis = xerrors.New("failed to analyze packages")
+	ErrPkgAnalysis = errors.New("failed to analyze packages")
 	// ErrNoPkgsDetected occurs when the required files for an OS package manager are not detected
-	ErrNoPkgsDetected = xerrors.New("no packages detected")
+	ErrNoPkgsDetected = errors.New("no packages detected")
 )
 
 type Config struct {
@@ -38,7 +39,7 @@ func (ac Config) Analyze(ctx context.Context, filterFunc types.FilterFunc) (type
 		dig := digest.Digest(layerID)
 		layerInfo, err := ac.analyzeLayer(ctx, dig, filterFunc)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to analyze layer: %s : %w", dig, err)
+			return nil, fmt.Errorf("failed to analyze layer: %s : %w", dig, err)
 		}
 		layerInfos = append(layerInfos, layerInfo)
 	}
@@ -46,7 +47,7 @@ func (ac Config) Analyze(ctx context.Context, filterFunc types.FilterFunc) (type
 	fileMap := docker.ApplyLayers(layerInfos)
 	config, err := ac.analyzeConfig(ctx)
 	if err != nil {
-		return nil, xerrors.Errorf("unable to analyze config: %w", err)
+		return nil, fmt.Errorf("unable to analyze config: %w", err)
 	}
 	fileMap["/config"] = config
 
@@ -56,7 +57,7 @@ func (ac Config) Analyze(ctx context.Context, filterFunc types.FilterFunc) (type
 func (ac Config) analyzeLayer(ctx context.Context, dig digest.Digest, filterFunc types.FilterFunc) (types.LayerInfo, error) {
 	files, opqDirs, whFiles, err := ac.Extractor.ExtractLayerFiles(ctx, dig, filterFunc)
 	if err != nil {
-		return types.LayerInfo{}, xerrors.Errorf("unable to extract files from layer %s: %w", dig, err)
+		return types.LayerInfo{}, fmt.Errorf("unable to extract files from layer %s: %w", dig, err)
 	}
 
 	layerInfo := types.LayerInfo{
@@ -71,7 +72,7 @@ func (ac Config) analyzeLayer(ctx context.Context, dig digest.Digest, filterFunc
 func (ac Config) analyzeConfig(ctx context.Context) (types.FileData, error) {
 	configBlob, err := ac.Extractor.ConfigBlob(ctx)
 	if err != nil {
-		return types.FileData{}, xerrors.Errorf("unable to get config blob: %w", err)
+		return types.FileData{}, fmt.Errorf("unable to get config blob: %w", err)
 	}
 
 	// special file for config

--- a/pkg/deckoder/extractor/docker/docker.go
+++ b/pkg/deckoder/extractor/docker/docker.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"context"
 	"crypto/sha256"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 	"time"
 
 	digest "github.com/opencontainers/go-digest"
-	"golang.org/x/xerrors"
 
 	"github.com/goodwithtech/dockle/pkg/deckoder/extractor/image/token/ecr"
 	"github.com/goodwithtech/dockle/pkg/deckoder/extractor/image/token/gcr"
@@ -70,7 +70,7 @@ func newDockerExtractor(ctx context.Context, imgRef image.Reference, transports 
 
 	img, err := image.NewImage(ctx, imgRef, transports, option)
 	if err != nil {
-		return Extractor{}, nil, xerrors.Errorf("unable to initialize a image struct: %w", err)
+		return Extractor{}, nil, fmt.Errorf("unable to initialize a image struct: %w", err)
 	}
 
 	cleanup := func() {
@@ -136,7 +136,7 @@ func (d Extractor) LayerIDs() []string {
 func (d Extractor) ExtractLayerFiles(ctx context.Context, dig digest.Digest, filterFunc types.FilterFunc) (types.FileMap, []string, []string, error) {
 	img, err := d.image.GetLayer(ctx, dig)
 	if err != nil {
-		return nil, nil, nil, xerrors.Errorf("failed to get a blob: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to get a blob: %w", err)
 	}
 	defer img.Close()
 
@@ -146,7 +146,7 @@ func (d Extractor) ExtractLayerFiles(ctx context.Context, dig digest.Digest, fil
 
 	files, opqDirs, whFiles, err := d.extractFiles(r, filterFunc)
 	if err != nil {
-		return nil, nil, nil, xerrors.Errorf("failed to extract files: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to extract files: %w", err)
 	}
 
 	return files, opqDirs, whFiles, nil
@@ -166,7 +166,7 @@ func (d Extractor) extractFiles(layer io.Reader, filterFunc types.FilterFunc) (t
 			break
 		}
 		if err != nil {
-			return data, nil, nil, xerrors.Errorf("failed to extract the archive: %w", err)
+			return data, nil, nil, fmt.Errorf("failed to extract the archive: %w", err)
 		}
 
 		filePath := hdr.Name
@@ -200,7 +200,7 @@ func (d Extractor) extractFiles(layer io.Reader, filterFunc types.FilterFunc) (t
 			// Determine if we should extract the element
 			extract, err = filterFunc(hdr)
 			if err != nil {
-				return data, nil, nil, xerrors.Errorf("failed to filtering file: %w", err)
+				return data, nil, nil, fmt.Errorf("failed to filtering file: %w", err)
 			}
 			if !extract {
 				continue
@@ -215,7 +215,7 @@ func (d Extractor) extractFiles(layer io.Reader, filterFunc types.FilterFunc) (t
 		if hdr.Typeflag == tar.TypeSymlink || hdr.Typeflag == tar.TypeLink || hdr.Typeflag == tar.TypeReg {
 			d, err := ioutil.ReadAll(tr)
 			if err != nil {
-				return nil, nil, nil, xerrors.Errorf("failed to read file: %w", err)
+				return nil, nil, nil, fmt.Errorf("failed to read file: %w", err)
 			}
 			data[filePath] = types.FileData{
 				Body:     d,

--- a/pkg/deckoder/extractor/image/image.go
+++ b/pkg/deckoder/extractor/image/image.go
@@ -2,6 +2,8 @@ package image
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 
 	"github.com/containers/image/v5/image"
@@ -11,7 +13,6 @@ import (
 	imageTypes "github.com/containers/image/v5/types"
 	"github.com/distribution/reference"
 	digest "github.com/opencontainers/go-digest"
-	"golang.org/x/xerrors"
 
 	"github.com/goodwithtech/dockle/pkg/types"
 )
@@ -57,7 +58,7 @@ func NewImage(ctx context.Context, image Reference, transports []string, option 
 	if !image.IsFile {
 		named, err := reference.ParseNormalizedNamed(image.Name)
 		if err != nil {
-			return RealImage{}, xerrors.Errorf("invalid image name: %w", err)
+			return RealImage{}, fmt.Errorf("invalid image name: %w", err)
 		}
 
 		// add 'latest' tag
@@ -83,7 +84,7 @@ func NewImage(ctx context.Context, image Reference, transports []string, option 
 
 	rawSource, src, err := newSource(ctx, image.Name, transports, sys)
 	if err != nil {
-		return RealImage{}, xerrors.Errorf("failed to initialize source: %w", err)
+		return RealImage{}, fmt.Errorf("failed to initialize source: %w", err)
 	}
 
 	return RealImage{
@@ -96,13 +97,13 @@ func NewImage(ctx context.Context, image Reference, transports []string, option 
 
 func newSource(ctx context.Context, imageName string, transports []string, sys *imageTypes.SystemContext) (
 	ImageSource, ImageCloser, error) {
-	err := xerrors.New("no valid transport")
+	err := errors.New("no valid transport")
 	for _, transport := range transports {
 		imgName := transport + imageName
 		var ref imageTypes.ImageReference
 		ref, err = alltransports.ParseImageName(imgName)
 		if err != nil {
-			return nil, nil, xerrors.Errorf("failed to parse an image name: %w", err)
+			return nil, nil, fmt.Errorf("failed to parse an image name: %w", err)
 		}
 
 		var rawSource imageTypes.ImageSource
@@ -115,7 +116,7 @@ func newSource(ctx context.Context, imageName string, transports []string, sys *
 		var src imageTypes.ImageCloser
 		src, err = image.FromSource(ctx, sys, rawSource)
 		if err != nil {
-			return nil, nil, xerrors.Errorf("failed to initialize: %w", err)
+			return nil, nil, fmt.Errorf("failed to initialize: %w", err)
 		}
 
 		return rawSource, src, nil
@@ -151,12 +152,12 @@ func (img RealImage) ConfigBlob(ctx context.Context) ([]byte, error) {
 func (img RealImage) GetLayer(ctx context.Context, dig digest.Digest) (io.ReadCloser, error) {
 	rc, _, err := img.rawSource.GetBlob(ctx, imageTypes.BlobInfo{Digest: dig, Size: -1}, img.blobInfoCache)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to download the layer(%s): %w", dig, err)
+		return nil, fmt.Errorf("failed to download the layer(%s): %w", dig, err)
 	}
 
 	stream, _, err := compression.AutoDecompress(rc)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to download the layer(%s): %w", dig, err)
+		return nil, fmt.Errorf("failed to download the layer(%s): %w", dig, err)
 	}
 
 	return stream, nil
@@ -165,12 +166,12 @@ func (img RealImage) GetLayer(ctx context.Context, dig digest.Digest) (io.ReadCl
 func (img RealImage) Close() error {
 	if img.src != nil {
 		if err := img.src.Close(); err != nil {
-			return xerrors.Errorf("unable to close image source: %w", err)
+			return fmt.Errorf("unable to close image source: %w", err)
 		}
 	}
 	if img.rawSource != nil {
 		if err := img.rawSource.Close(); err != nil {
-			return xerrors.Errorf("unable to close image source: %w", err)
+			return fmt.Errorf("unable to close image source: %w", err)
 		}
 	}
 	return nil

--- a/pkg/deckoder/extractor/image/token/ecr/ecr.go
+++ b/pkg/deckoder/extractor/image/token/ecr/ecr.go
@@ -3,6 +3,7 @@ package ecr
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"strings"
 
 	"github.com/goodwithtech/dockle/pkg/types"
@@ -11,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
-	"golang.org/x/xerrors"
 )
 
 const ecrURL = "amazonaws.com"
@@ -41,11 +41,11 @@ func getConfig(ctx context.Context, option types.DockerOption) (aws.Config, erro
 
 func (e *ECR) CheckOptions(domain string, option types.DockerOption) error {
 	if !strings.HasSuffix(domain, ecrURL) {
-		return xerrors.Errorf("ECR : %w", types.InvalidURLPattern)
+		return fmt.Errorf("ECR : %w", types.InvalidURLPattern)
 	}
 	cfg, err := getConfig(context.TODO(), option)
 	if err != nil {
-		return xerrors.Errorf("failed to load AWS config: %w", err)
+		return fmt.Errorf("failed to load AWS config: %w", err)
 	}
 	e.Client = ecr.NewFromConfig(cfg)
 	return nil
@@ -55,12 +55,12 @@ func (e *ECR) GetCredential(ctx context.Context) (username, password string, err
 	input := &ecr.GetAuthorizationTokenInput{}
 	result, err := e.Client.GetAuthorizationToken(ctx, input)
 	if err != nil {
-		return "", "", xerrors.Errorf("failed to get authorization token: %w", err)
+		return "", "", fmt.Errorf("failed to get authorization token: %w", err)
 	}
 	for _, data := range result.AuthorizationData {
 		b, err := base64.StdEncoding.DecodeString(aws.ToString(data.AuthorizationToken))
 		if err != nil {
-			return "", "", xerrors.Errorf("base64 decode failed: %w", err)
+			return "", "", fmt.Errorf("base64 decode failed: %w", err)
 		}
 		// e.g. AWS:eyJwYXlsb2...
 		split := strings.SplitN(string(b), ":", 2)

--- a/pkg/deckoder/extractor/image/token/ecr/ecr_test.go
+++ b/pkg/deckoder/extractor/image/token/ecr/ecr_test.go
@@ -2,10 +2,10 @@ package ecr
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/goodwithtech/dockle/pkg/types"
-	"golang.org/x/xerrors"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
@@ -33,7 +33,7 @@ func TestCheckOptions(t *testing.T) {
 		a := &ECR{}
 		err := a.CheckOptions(v.domain, v.opt)
 		if err != nil {
-			if !xerrors.Is(err, v.wantErr) {
+			if !errors.Is(err, v.wantErr) {
 				t.Errorf("[%s]\nexpected error based on %v\nactual : %v", testname, v.wantErr, err)
 			}
 			continue

--- a/pkg/deckoder/extractor/image/token/gcr/gcr.go
+++ b/pkg/deckoder/extractor/image/token/gcr/gcr.go
@@ -2,11 +2,10 @@ package gcr
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/goodwithtech/dockle/pkg/types"
-
-	"golang.org/x/xerrors"
 
 	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/config"
 	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/credhelper"
@@ -22,7 +21,7 @@ const gcrURL = "gcr.io"
 
 func (g *GCR) CheckOptions(domain string, d types.DockerOption) error {
 	if !strings.HasSuffix(domain, gcrURL) {
-		return xerrors.Errorf("GCR : %w", types.InvalidURLPattern)
+		return fmt.Errorf("GCR : %w", types.InvalidURLPattern)
 	}
 	g.domain = domain
 	if d.GcpCredPath != "" {
@@ -36,14 +35,14 @@ func (g *GCR) GetCredential(ctx context.Context) (username, password string, err
 	if g.Store == nil {
 		credStore, err = store.DefaultGCRCredStore()
 		if err != nil {
-			return "", "", xerrors.Errorf("failed to get GCRCredStore: %w", err)
+			return "", "", fmt.Errorf("failed to get GCRCredStore: %w", err)
 		}
 	} else {
 		credStore = g.Store
 	}
 	userCfg, err := config.LoadUserConfig()
 	if err != nil {
-		return "", "", xerrors.Errorf("failed to load user config: %w", err)
+		return "", "", fmt.Errorf("failed to load user config: %w", err)
 	}
 	helper := credhelper.NewGCRCredentialHelper(credStore, userCfg)
 	return helper.Get(g.domain)

--- a/pkg/deckoder/extractor/image/token/gcr/gcr_test.go
+++ b/pkg/deckoder/extractor/image/token/gcr/gcr_test.go
@@ -1,12 +1,11 @@
 package gcr
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/docker-credential-gcr/v2/store"
-
-	"golang.org/x/xerrors"
 
 	"github.com/goodwithtech/dockle/pkg/types"
 )
@@ -43,7 +42,7 @@ func TestCheckOptions(t *testing.T) {
 				t.Errorf("%s : expected error but no error", testname)
 				continue
 			}
-			if !xerrors.Is(err, v.wantErr) {
+			if !errors.Is(err, v.wantErr) {
 				t.Errorf("[%s]\nexpected error based on %v\nactual : %v", testname, v.wantErr, err)
 			}
 			continue


### PR DESCRIPTION
## Summary

Removes the dependency on `golang.org/x/xerrors`, which is frozen/archived upstream. Since Go 1.13, the standard library natively supports error wrapping with `fmt.Errorf` + `%w` and inspection via `errors.Is`/`errors.As`, so xerrors is no longer needed.

## Changes

- `xerrors.Errorf("...: %w", err)` → `fmt.Errorf("...: %w", err)` — every call site uses a single, trailing `%w`, so wrapping semantics are byte-for-byte identical
- `xerrors.New(...)` → `errors.New(...)` (sentinel errors in `pkg/deckoder/analyzer` and `pkg/deckoder/extractor/image`)
- `xerrors.Is(...)` → `errors.Is(...)` in the ECR/GCR token tests
- `go mod tidy` — `golang.org/x/xerrors` is gone from `go.mod` (a few stale `go.sum` graph entries remain from historical versions of go-cmp/x/tools, but nothing in the build pulls it in)

Affected packages: `pkg/deckoder/analyzer`, `pkg/deckoder/extractor/docker`, `pkg/deckoder/extractor/image`, `pkg/deckoder/extractor/image/token/{ecr,gcr}`.

## Verification

- `go build` and `CGO_ENABLED=0 go test ./...` pass
- Functional check: `go run cmd/dockle/main.go --input pkg/scanner/testdata/scratch.tar` produces output identical to master (diffed) with exit code 0

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)