### PR TITLE
refactor: migrate urfave/cli from v1 to v3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Releases are built by GoReleaser (`goreleaser.yaml`) via GitHub Actions when a `
 
 The scan pipeline flows: **CLI → scanner → extractor (`pkg/deckoder`) → assessors → assessment map → report writer**.
 
-1. **Entry point**: `cmd/dockle/main.go` calls `pkg.NewApp()` (`pkg/app.go`), which defines all CLI flags using `urfave/cli` v1. The action is `pkg.Run` (`pkg/run.go`), which wires everything together. `config.CreateFromCli` (`config/config.go`) populates the global `config.Conf` (ignore rules from flags/`DOCKLE_IGNORES`/`.dockleignore`, exit code, etc.).
+1. **Entry point**: `cmd/dockle/main.go` calls `pkg.NewApp()` (`pkg/app.go`), which defines all CLI flags using `urfave/cli` v3. The action is `pkg.Run` (`pkg/run.go`), which wires everything together. `config.CreateFromCli` (`config/config.go`) populates the global `config.Conf` (ignore rules from flags/`DOCKLE_IGNORES`/`.dockleignore`, exit code, etc.).
 
 2. **Image extraction**: `pkg/scanner/scan.go` uses `pkg/deckoder` (formerly the separate `github.com/goodwithtech/deckoder` library, now integrated into this repository — see `pkg/deckoder/README.md`) to fetch the image from a Docker daemon, remote registry, or tar archive. Only files that assessors declare they need — via `RequiredFiles()` / `RequiredExtensions()` / `RequiredPermissions()` — are extracted, using a tar filter function. Acceptance flags (`--accept-file`, `--accept-file-extension`) remove files from that filter.
 

--- a/cmd/dockle/main.go
+++ b/cmd/dockle/main.go
@@ -1,15 +1,17 @@
 package main
 
 import (
-	"github.com/goodwithtech/dockle/pkg"
-	"github.com/goodwithtech/dockle/pkg/log"
+	"context"
 	l "log"
 	"os"
+
+	"github.com/goodwithtech/dockle/pkg"
+	"github.com/goodwithtech/dockle/pkg/log"
 )
 
 func main() {
 	app := pkg.NewApp()
-	err := app.Run(os.Args)
+	err := app.Run(context.Background(), os.Args)
 
 	if err != nil {
 		if log.Logger != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,7 @@ import (
 	"github.com/goodwithtech/dockle/pkg/types"
 
 	"github.com/goodwithtech/dockle/pkg/log"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v3"
 )
 
 const (
@@ -32,12 +32,12 @@ type Config struct {
 
 var Conf Config
 
-func CreateFromCli(c *cli.Context) {
-	ignoreRules := c.StringSlice("ignore")
+func CreateFromCli(cmd *cli.Command) {
+	ignoreRules := cmd.StringSlice("ignore")
 	Conf = Config{
 		IgnoreMap: getIgnoreCheckpointMap(ignoreRules),
-		ExitCode:  c.Int("exit-code"),
-		ExitLevel: getExitLevel(c.String("exit-level")),
+		ExitCode:  cmd.Int("exit-code"),
+		ExitLevel: getExitLevel(cmd.String("exit-level")),
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/owenrumney/go-sarif/v2 v2.3.3
 	github.com/stretchr/testify v1.11.1
-	github.com/urfave/cli v1.22.17
+	github.com/urfave/cli/v3 v3.10.1
 	go.uber.org/zap v1.28.0
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da
 )
@@ -53,7 +53,6 @@ require (
 	github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 // indirect
 	github.com/containers/ocicrypt v1.2.1 // indirect
 	github.com/containers/storage v1.59.1 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/cyphar/filepath-securejoin v0.5.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/docker/cli v29.6.1+incompatible // indirect
@@ -88,7 +87,6 @@ require (
 	github.com/opencontainers/selinux v1.15.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/sylabs/sif/v2 v2.21.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,6 @@ github.com/containers/ocicrypt v1.2.1 h1:0qIOTT9DoYwcKmxSt8QJt+VzMY18onl9jUXsxpV
 github.com/containers/ocicrypt v1.2.1/go.mod h1:aD0AAqfMp0MtwqWgHM1bUwe1anx0VazI108CRrSKINQ=
 github.com/containers/storage v1.59.1 h1:11Zu68MXsEQGBBd+GadPrHPpWeqjKS8hJDGiAHgIqDs=
 github.com/containers/storage v1.59.1/go.mod h1:KoAYHnAjP3/cTsRS+mmWZGkufSY2GACiKQ4V3ZLQnR0=
-github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
-github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.5.1 h1:eYgfMq5yryL4fbWfkLpFFy2ukSELzaJOTaUTuh+oF48=
 github.com/cyphar/filepath-securejoin v0.5.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/d4l3k/messagediff v1.2.2-0.20180726183240-b9e99b2f9263 h1:Ot817IZ8L+/ZlkfVJ0ZnngYA6GnmcvcxR7lrIz/iZDc=
@@ -235,8 +233,6 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
-github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sebdah/goldie/v2 v2.5.5 h1:rx1mwF95RxZ3/83sdS4Yp7t2C5TCokvWP4TBRbAyEWY=
 github.com/sebdah/goldie/v2 v2.5.5/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
@@ -253,8 +249,6 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/sylabs/sif/v2 v2.21.1 h1:GZ0b5//AFAqJEChd8wHV/uSKx/l1iuGYwjR8nx+4wPI=
@@ -265,8 +259,8 @@ github.com/toqueteos/webbrowser v1.2.1 h1:O7IsnnU7XQyJ1nHMRfAktUUJOAZD3aQyUVnxzh
 github.com/toqueteos/webbrowser v1.2.1/go.mod h1:XWoZq4cyp9WeUeak7w7LXRUQf1F1ATJMir8RTqb4ayM=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/urfave/cli v1.22.17 h1:SYzXoiPfQjHBbkYxbew5prZHS1TOLT3ierW8SYLqtVQ=
-github.com/urfave/cli v1.22.17/go.mod h1:b0ht0aqgH/6pBYzzxURyrM4xXNgsoT/n2ZzwQiEhNVo=
+github.com/urfave/cli/v3 v3.10.1 h1:7Kx9H50hrHbRbyxgO1KP6/BcbiGRz0uYh5YyQ30JEEY=
+github.com/urfave/cli/v3 v3.10.1/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 github.com/vbatts/tar-split v0.12.1 h1:CqKoORW7BUWBe7UL/iqTVvkTBOF8UvOMKOIZykxnnbo=
 github.com/vbatts/tar-split v0.12.1/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
@@ -402,7 +396,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/app.go
+++ b/pkg/app.go
@@ -3,181 +3,199 @@ package pkg
 import (
 	"time"
 
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v3"
 )
 
 var (
 	version = "dev"
 )
 
-/*
-NewApp Factory for Dockle CLI creation.
-An Enabler for programmatic usage of Dockle
-*/
-func NewApp() *cli.App {
-	cli.AppHelpTemplate = `NAME:
+// rootHelpTemplate keeps the compact single-command help layout that
+// Dockle has always used (no COMMANDS section, two-space indentation).
+const rootHelpTemplate = `NAME:
   {{.Name}}{{if .Usage}} - {{.Usage}}{{end}}
 USAGE:
-  {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} {{if .VisibleFlags}}[options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}
+  {{if .UsageText}}{{.UsageText}}{{else}}{{.FullName}} {{if .VisibleFlags}}[options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Version}}{{if not .HideVersion}}
 VERSION:
   {{.Version}}{{end}}{{end}}{{if .Description}}
 DESCRIPTION:
   {{.Description}}{{end}}{{if len .Authors}}
 AUTHOR{{with $length := len .Authors}}{{if ne 1 $length}}S{{end}}{{end}}:
   {{range $index, $author := .Authors}}{{if $index}}
-  {{end}}{{$author}}{{end}}{{end}}{{if .VisibleCommands}}
+  {{end}}{{$author}}{{end}}{{end}}{{if .VisibleFlags}}
 OPTIONS:
   {{range $index, $option := .VisibleFlags}}{{if $index}}
   {{end}}{{$option}}{{end}}{{end}}
 `
-	app := cli.NewApp()
 
-	var dockerSockPath string
-	app.Name = "dockle"
-	app.Version = version
-	app.ArgsUsage = "image_name"
+/*
+NewApp Factory for Dockle CLI creation.
+An Enabler for programmatic usage of Dockle
+*/
+func NewApp() *cli.Command {
+	cmd := &cli.Command{
+		Name:      "dockle",
+		Version:   version,
+		ArgsUsage: "image_name",
+		Usage:     "Container Image Linter for Security, Helping build the Best-Practice Docker Image, Easy to start",
 
-	app.Usage = "Container Image Linter for Security, Helping build the Best-Practice Docker Image, Easy to start"
+		CustomRootCommandHelpTemplate: rootHelpTemplate,
 
-	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:  "input",
-			Usage: "input file path instead of image name",
-		},
-		cli.StringSliceFlag{
-			Name:   "ignore, i",
-			EnvVar: "DOCKLE_IGNORES",
-			Usage:  "checkpoints to ignore. You can use .dockleignore too.",
-		},
-		cli.StringSliceFlag{
-			Name:   "accept-key, ak",
-			EnvVar: "DOCKLE_ACCEPT_KEYS",
-			Usage:  "For CIS-DI-0010. You can add acceptable keywords. e.g) -ak GPG_KEY -ak KEYCLOAK",
-		},
-		cli.StringSliceFlag{
-			Name:   "sensitive-word, sw",
-			EnvVar: "DOCKLE_REJECT_KEYS",
-			Usage:  "For CIS-DI-0010. You can add sensitive keywords to look for. e.g) -ak api_password -sw keys",
-		},
-		cli.StringSliceFlag{
-			Name:   "accept-file, af",
-			EnvVar: "DOCKLE_ACCEPT_FILES",
-			Usage:  "For CIS-DI-0010. You can add acceptable file names. e.g) -af id_rsa -af config.json",
-		},
-		cli.StringSliceFlag{
-			Name:   "sensitive-file, sf",
-			EnvVar: "DOCKLE_REJECT_FILES",
-			Usage:  "For CIS-DI-0010. You can add sensitive files to look for. e.g) -sf .git",
-		},
-		cli.StringSliceFlag{
-			Name:   "accept-file-extension, ae",
-			EnvVar: "DOCKLE_ACCEPT_FILE_EXTENSIONS",
-			Usage:  "For CIS-DI-0010. You can add acceptable file extensions. e.g) -ae pem -ae log",
-		},
-		cli.StringSliceFlag{
-			Name:   "sensitive-file-extension, se",
-			EnvVar: "DOCKLE_REJECT_FILE_EXTENSIONS",
-			Usage:  "For CIS-DI-0010. You can add sensitive files to look for. e.g) -se .pfx",
-		},
-		cli.StringFlag{
-			Name:   "format, f",
-			Value:  "",
-			EnvVar: "DOCKLE_OUTPUT_FORMAT",
-			Usage:  "output format (list, json, sarif)",
-		},
-		cli.StringFlag{
-			Name:   "output, o",
-			EnvVar: "DOCKLE_OUTPUT_FILE",
-			Usage:  "output file name",
-		},
-		cli.IntFlag{
-			Name:   "exit-code, c",
-			Value:  0,
-			EnvVar: "DOCKLE_EXIT_CODE",
-			Usage:  "exit code when alert were found",
-		},
-		cli.StringFlag{
-			Name:   "exit-level, l",
-			Value:  "WARN",
-			EnvVar: "DOCKLE_EXIT_LEVEL",
-			Usage:  "change ABEND level when use exit-code=1",
-		},
-		cli.BoolFlag{
-			Name:   "debug, d",
-			EnvVar: "DOCKLE_DEBUG",
-			Usage:  "debug mode",
-		},
-		cli.BoolFlag{
-			Name:   "quiet, q",
-			EnvVar: "DOCKLE_QUIET",
-			Usage:  "suppress log output",
-		},
-		cli.BoolFlag{
-			Name:   "no-color",
-			EnvVar: "NO_COLOR",
-			Usage:  "disabling color output",
-		},
-		cli.BoolFlag{
-			Name:   "version-check",
-			EnvVar: "DOCKLE_VERSION_CHECK",
-			Usage:  "show an update notification",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "input",
+				Usage: "input file path instead of image name",
+			},
+			&cli.StringSliceFlag{
+				Name:    "ignore",
+				Aliases: []string{"i"},
+				Sources: cli.EnvVars("DOCKLE_IGNORES"),
+				Usage:   "checkpoints to ignore. You can use .dockleignore too.",
+			},
+			&cli.StringSliceFlag{
+				Name:    "accept-key",
+				Aliases: []string{"ak"},
+				Sources: cli.EnvVars("DOCKLE_ACCEPT_KEYS"),
+				Usage:   "For CIS-DI-0010. You can add acceptable keywords. e.g) -ak GPG_KEY -ak KEYCLOAK",
+			},
+			&cli.StringSliceFlag{
+				Name:    "sensitive-word",
+				Aliases: []string{"sw"},
+				Sources: cli.EnvVars("DOCKLE_REJECT_KEYS"),
+				Usage:   "For CIS-DI-0010. You can add sensitive keywords to look for. e.g) -ak api_password -sw keys",
+			},
+			&cli.StringSliceFlag{
+				Name:    "accept-file",
+				Aliases: []string{"af"},
+				Sources: cli.EnvVars("DOCKLE_ACCEPT_FILES"),
+				Usage:   "For CIS-DI-0010. You can add acceptable file names. e.g) -af id_rsa -af config.json",
+			},
+			&cli.StringSliceFlag{
+				Name:    "sensitive-file",
+				Aliases: []string{"sf"},
+				Sources: cli.EnvVars("DOCKLE_REJECT_FILES"),
+				Usage:   "For CIS-DI-0010. You can add sensitive files to look for. e.g) -sf .git",
+			},
+			&cli.StringSliceFlag{
+				Name:    "accept-file-extension",
+				Aliases: []string{"ae"},
+				Sources: cli.EnvVars("DOCKLE_ACCEPT_FILE_EXTENSIONS"),
+				Usage:   "For CIS-DI-0010. You can add acceptable file extensions. e.g) -ae pem -ae log",
+			},
+			&cli.StringSliceFlag{
+				Name:    "sensitive-file-extension",
+				Aliases: []string{"se"},
+				Sources: cli.EnvVars("DOCKLE_REJECT_FILE_EXTENSIONS"),
+				Usage:   "For CIS-DI-0010. You can add sensitive files to look for. e.g) -se .pfx",
+			},
+			&cli.StringFlag{
+				Name:    "format",
+				Aliases: []string{"f"},
+				Value:   "",
+				Sources: cli.EnvVars("DOCKLE_OUTPUT_FORMAT"),
+				Usage:   "output format (list, json, sarif)",
+			},
+			&cli.StringFlag{
+				Name:    "output",
+				Aliases: []string{"o"},
+				Sources: cli.EnvVars("DOCKLE_OUTPUT_FILE"),
+				Usage:   "output file name",
+			},
+			&cli.IntFlag{
+				Name:    "exit-code",
+				Aliases: []string{"c"},
+				Value:   0,
+				Sources: cli.EnvVars("DOCKLE_EXIT_CODE"),
+				Usage:   "exit code when alert were found",
+			},
+			&cli.StringFlag{
+				Name:    "exit-level",
+				Aliases: []string{"l"},
+				Value:   "WARN",
+				Sources: cli.EnvVars("DOCKLE_EXIT_LEVEL"),
+				Usage:   "change ABEND level when use exit-code=1",
+			},
+			&cli.BoolFlag{
+				Name:    "debug",
+				Aliases: []string{"d"},
+				Sources: cli.EnvVars("DOCKLE_DEBUG"),
+				Usage:   "debug mode",
+			},
+			&cli.BoolFlag{
+				Name:    "quiet",
+				Aliases: []string{"q"},
+				Sources: cli.EnvVars("DOCKLE_QUIET"),
+				Usage:   "suppress log output",
+			},
+			&cli.BoolFlag{
+				Name:    "no-color",
+				Sources: cli.EnvVars("NO_COLOR"),
+				Usage:   "disabling color output",
+			},
+			&cli.BoolFlag{
+				Name:    "version-check",
+				Sources: cli.EnvVars("DOCKLE_VERSION_CHECK"),
+				Usage:   "show an update notification",
+			},
+
+			// Registry flag
+			&cli.DurationFlag{
+				Name:    "timeout",
+				Aliases: []string{"t"},
+				Value:   time.Second * 90,
+				Sources: cli.EnvVars("DOCKLE_TIMEOUT"),
+				Usage:   "docker timeout. e.g) 5s, 5m...",
+			},
+			&cli.BoolFlag{
+				Name:    "use-xdg",
+				Aliases: []string{"x"},
+				Sources: cli.EnvVars("USE_XDG"),
+				Usage:   "Docker daemon host file XDG_RUNTIME_DIR",
+			},
+			&cli.StringFlag{
+				Name:    "host",
+				Sources: cli.EnvVars("DOCKLE_HOST"),
+				Usage:   "docker daemon host",
+			},
+			&cli.StringFlag{
+				Name:    "authurl",
+				Sources: cli.EnvVars("DOCKLE_AUTH_URL"),
+				Usage:   "registry authenticate url",
+			},
+			&cli.StringFlag{
+				Name:    "username",
+				Sources: cli.EnvVars("DOCKLE_USERNAME"),
+				Usage:   "registry login username",
+			},
+			&cli.StringFlag{
+				Name:    "password",
+				Sources: cli.EnvVars("DOCKLE_PASSWORD"),
+				Usage:   "registry login password. Using --password via CLI is insecure.",
+			},
+			&cli.BoolFlag{
+				Name:    "insecure",
+				Sources: cli.EnvVars("DOCKLE_INSECURE"),
+				Usage:   "registry connect insecure",
+			},
+			&cli.BoolFlag{
+				Name: "nonssl",
+				// v1 used BoolTFlag, so the default stays true.
+				Value:   true,
+				Sources: cli.EnvVars("DOCKLE_NON_SSL"),
+				Usage:   "registry connect without ssl",
+			},
+			&cli.StringFlag{
+				Name:    "cert-path",
+				Sources: cli.EnvVars("DOCKLE_CERT_PATH"),
+				Usage:   "docker daemon certificate path",
+			},
+			&cli.StringFlag{
+				Name:  "cache-dir",
+				Usage: "cache directory",
+			},
 		},
 
-		// Registry flag
-		cli.DurationFlag{
-			Name:   "timeout, t",
-			Value:  time.Second * 90,
-			EnvVar: "DOCKLE_TIMEOUT",
-			Usage:  "docker timeout. e.g) 5s, 5m...",
-		},
-		cli.BoolFlag{
-			Name:   "use-xdg, x",
-			EnvVar: "USE_XDG",
-			Usage:  "Docker daemon host file XDG_RUNTIME_DIR",
-		},
-		cli.StringFlag{
-			Name:   "host",
-			EnvVar: "DOCKLE_HOST",
-			Usage:  "docker daemon host",
-			Value:  dockerSockPath,
-		},
-		cli.StringFlag{
-			Name:   "authurl",
-			EnvVar: "DOCKLE_AUTH_URL",
-			Usage:  "registry authenticate url",
-		},
-		cli.StringFlag{
-			Name:   "username",
-			EnvVar: "DOCKLE_USERNAME",
-			Usage:  "registry login username",
-		},
-		cli.StringFlag{
-			Name:   "password",
-			EnvVar: "DOCKLE_PASSWORD",
-			Usage:  "registry login password. Using --password via CLI is insecure.",
-		},
-		cli.BoolFlag{
-			Name:   "insecure",
-			EnvVar: "DOCKLE_INSECURE",
-			Usage:  "registry connect insecure",
-		},
-		cli.BoolTFlag{
-			Name:   "nonssl",
-			EnvVar: "DOCKLE_NON_SSL",
-			Usage:  "registry connect without ssl",
-		},
-		cli.StringFlag{
-			Name:   "cert-path",
-			EnvVar: "DOCKLE_CERT_PATH",
-			Usage:  "docker daemon certificate path",
-			Value:  dockerSockPath,
-		},
-		cli.StringFlag{
-			Name:  "cache-dir",
-			Usage: "cache directory",
-		},
+		Action: Run,
 	}
-
-	app.Action = Run
-	return app
+	return cmd
 }

--- a/pkg/run.go
+++ b/pkg/run.go
@@ -20,56 +20,56 @@ import (
 
 	"github.com/goodwithtech/dockle/pkg/scanner"
 
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v3"
 
 	"github.com/goodwithtech/dockle/pkg/log"
 	"github.com/goodwithtech/dockle/pkg/types"
 )
 
-func Run(c *cli.Context) (err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), c.Duration("timeout"))
+func Run(baseCtx context.Context, cmd *cli.Command) (err error) {
+	ctx, cancel := context.WithTimeout(baseCtx, cmd.Duration("timeout"))
 	defer cancel()
-	debug := c.Bool("debug")
-	quiet := c.Bool("quiet")
+	debug := cmd.Bool("debug")
+	quiet := cmd.Bool("quiet")
 	if err = log.InitLogger(debug, quiet); err != nil {
 		l.Fatal(err)
 	}
 
-	config.CreateFromCli(c)
+	config.CreateFromCli(cmd)
 
-	cliVersion := "v" + c.App.Version
-	if c.Bool("version-check") {
+	cliVersion := "v" + cmd.Root().Version
+	if cmd.Bool("version-check") {
 		latestVersion, err := utils.FetchLatestVersion(ctx)
 		// check latest version
 		if err != nil {
 			log.Logger.Infof("Failed to check latest version. %s", err)
-		} else if cliVersion != latestVersion && c.App.Version != "dev" {
+		} else if cliVersion != latestVersion && cmd.Root().Version != "dev" {
 			log.Logger.Warnf("A new version %s is now available! You have %s.", latestVersion, cliVersion)
 		}
 	} else {
 		log.Logger.Debug("Skipped update confirmation")
 	}
 
-	args := c.Args()
-	filePath := c.String("input")
-	if filePath == "" && len(args) == 0 {
+	args := cmd.Args()
+	filePath := cmd.String("input")
+	if filePath == "" && args.Len() == 0 {
 		log.Logger.Info(`"dockle" requires at least 1 argument or --input option.`)
-		cli.ShowAppHelpAndExit(c, 1)
+		cli.ShowRootCommandHelpAndExit(cmd, 1)
 		return
 	}
 	// set docker option
 	dockerOption := types.DockerOption{
-		Timeout:               c.Duration("timeout"),
-		UserName:              c.String("username"),
-		Password:              c.String("password"),
-		InsecureSkipTLSVerify: c.Bool("insecure"),
-		DockerDaemonHost:      getDockerSockPath(c),
-		DockerDaemonCertPath:  c.String("cert-path"),
+		Timeout:               cmd.Duration("timeout"),
+		UserName:              cmd.String("username"),
+		Password:              cmd.String("password"),
+		InsecureSkipTLSVerify: cmd.Bool("insecure"),
+		DockerDaemonHost:      getDockerSockPath(cmd),
+		DockerDaemonCertPath:  cmd.String("cert-path"),
 		SkipPing:              true,
 	}
 	var imageName string
 	if filePath == "" {
-		imageName = args[0]
+		imageName = args.First()
 	}
 
 	var useLatestTag bool
@@ -79,12 +79,12 @@ func Run(c *cli.Context) (err error) {
 			return fmt.Errorf("invalid image: %w", err)
 		}
 	}
-	manifest.AddSensitiveWords(c.StringSlice("sensitive-word"))
-	manifest.AddAcceptanceKeys(c.StringSlice("accept-key"))
-	credential.AddSensitiveFiles(c.StringSlice("sensitive-file"))
-	scanner.AddAcceptanceFiles(c.StringSlice("accept-file"))
-	credential.AddSensitiveFileExtensions(c.StringSlice("sensitive-file-extension"))
-	scanner.AddAcceptanceExtensions(c.StringSlice("accept-file-extension"))
+	manifest.AddSensitiveWords(cmd.StringSlice("sensitive-word"))
+	manifest.AddAcceptanceKeys(cmd.StringSlice("accept-key"))
+	credential.AddSensitiveFiles(cmd.StringSlice("sensitive-file"))
+	scanner.AddAcceptanceFiles(cmd.StringSlice("accept-file"))
+	credential.AddSensitiveFileExtensions(cmd.StringSlice("sensitive-file-extension"))
+	scanner.AddAcceptanceExtensions(cmd.StringSlice("accept-file-extension"))
 	log.Logger.Debug("Start assessments...")
 	assessments, err := scanner.ScanImage(ctx, imageName, filePath, dockerOption)
 	if err != nil {
@@ -105,7 +105,7 @@ func Run(c *cli.Context) (err error) {
 
 	assessmentMap := types.CreateAssessmentMap(assessments, config.Conf.IgnoreMap, debug)
 	// Store ignore checkpoint code
-	o := c.String("output")
+	o := cmd.String("output")
 	output := os.Stdout
 	if o != "" {
 		if output, err = os.Create(o); err != nil {
@@ -114,13 +114,13 @@ func Run(c *cli.Context) (err error) {
 	}
 
 	var writer report.Writer
-	switch format := c.String("format"); format {
+	switch format := cmd.String("format"); format {
 	case "json":
 		writer = &report.JsonWriter{Output: output, ImageName: imageName}
 	case "sarif":
 		writer = &report.SarifWriter{Output: output}
 	default:
-		writer = &report.ListWriter{Output: output, NoColor: c.Bool("no-color")}
+		writer = &report.ListWriter{Output: output, NoColor: cmd.Bool("no-color")}
 	}
 
 	abend, err := writer.Write(assessmentMap)
@@ -135,12 +135,12 @@ func Run(c *cli.Context) (err error) {
 	return nil
 }
 
-func getDockerSockPath(c *cli.Context) string {
-	if c.String("host") != "" {
-		return c.String("host")
+func getDockerSockPath(cmd *cli.Command) string {
+	if cmd.String("host") != "" {
+		return cmd.String("host")
 	}
 	xdgRuntimeDir := os.Getenv("XDG_RUNTIME_DIR")
-	if c.Bool("use-xdg") && xdgRuntimeDir != "" {
+	if cmd.Bool("use-xdg") && xdgRuntimeDir != "" {
 		return fmt.Sprintf("unix://%s/docker.sock", xdgRuntimeDir)
 	}
 	return "unix:///var/run/docker.sock"


### PR DESCRIPTION
## Motivation

`urfave/cli` v1 is in maintenance mode and no longer receives feature development; v3 is the actively developed line. This PR migrates Dockle's CLI layer from `github.com/urfave/cli` v1.22.17 to `github.com/urfave/cli/v3` v3.10.1 as a careful, behavior-preserving refactor. Every flag, alias, and `DOCKLE_*` environment-variable fallback keeps working identically.

## API changes applied

| v1 | v3 |
| --- | --- |
| `cli.App` via `cli.NewApp()` | `*cli.Command` root struct (`pkg/app.go`) |
| `app.Run(os.Args)` | `cmd.Run(context.Background(), os.Args)` (`cmd/dockle/main.go`) |
| `Name: "ignore, i"` | `Name: "ignore", Aliases: []string{"i"}` |
| `EnvVar: "DOCKLE_IGNORES"` | `Sources: cli.EnvVars("DOCKLE_IGNORES")` |
| `cli.BoolTFlag` (`--nonssl`) | `cli.BoolFlag{Value: true}` |
| `Action: func(c *cli.Context) error` | `Action: func(ctx context.Context, cmd *cli.Command) error` (`pkg/run.go`) |
| `cli.AppHelpTemplate` | `Command.CustomRootCommandHelpTemplate` (compact single-command layout preserved) |
| `cli.ShowAppHelpAndExit(c, 1)` | `cli.ShowRootCommandHelpAndExit(cmd, 1)` |
| `config.CreateFromCli(*cli.Context)` | `config.CreateFromCli(*cli.Command)` (`config/config.go`) |

The scan timeout context now derives from the context passed into the action instead of a fresh `context.Background()`. `go mod tidy` removed the v1 module and its transitive deps (`go-md2man`, `blackfriday`).

## Verification

Baseline outputs and exit codes were recorded with a v1 build of master, then every command was re-run with the v3 build and diffed. `--input pkg/scanner/testdata/scratch.tar` refers to the checked-in test image tar.

| Check | v1 exit | v3 exit | Output match |
| --- | --- | --- | --- |
| `--help` | 0 | 0 | All flags/aliases/env hints present (formatting cosmetically differs, see below) |
| `--version` | 0 | 0 | Identical (`dockle version dev`) |
| `-v` | 0 | 0 | Identical |
| `--input scratch.tar` (list output) | 0 | 0 | Identical |
| `-f json --input scratch.tar` | 0 | 0 | Identical |
| `DOCKLE_IGNORES=CIS-DI-0005,CIS-DI-0006` env fallback | 0 | 0 | Identical |
| `--ignore CIS-DI-0005 --ignore CIS-DI-0006` | 0 | 0 | Identical |
| `-i CIS-DI-0005` (alias) | 0 | 0 | Identical |
| `--exit-code 1` | 1 | 1 | Identical |
| `DOCKLE_EXIT_CODE=1` env fallback | 1 | 1 | Identical |
| `--exit-code 1 --exit-level FATAL` | 1 | 1 | Identical |
| `--debug` | 0 | 0 | Identical after stripping log timestamps |
| `DOCKLE_DEBUG=1` env fallback | 0 | 0 | Identical after stripping log timestamps |
| `--no-color` | 0 | 0 | Identical |
| `--timeout 200s` | 0 | 0 | Identical |
| `DOCKLE_TIMEOUT=120s` env fallback | 0 | 0 | Identical |
| `DOCKLE_OUTPUT_FORMAT=json` env fallback | 0 | 0 | Identical |
| `--accept-file id_rsa --accept-file-extension pem` | 0 | 0 | Identical |
| `.dockleignore` file in cwd | 0 | 0 | Identical |
| no args (help + INFO message) | 1 | 1 | Identical modulo help formatting |
| unknown flag `--nope` | 1 | 1 | — |
| `CGO_ENABLED=0 go test ./...` | — | pass | — |

## Intentional differences (cosmetic only)

- Help flag descriptions render as v3's stringer format, e.g. `--format string, -f string` instead of `--format value, -f value`; slice flags show v3's repeatable-flag hint `[ --ignore string, -i string ]`. All flags, aliases, and `[$ENV_VAR]` hints remain listed in the same order.
- The USAGE line prints the command name `dockle` (v3 `.FullName`) instead of the invoked binary's basename (v1 `.HelpName`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)