### PR TITLE
Guard against malformed /etc/group and /etc/passwd lines

### DIFF
--- a/pkg/assessor/group/group.go
+++ b/pkg/assessor/group/group.go
@@ -30,7 +30,14 @@ func (a GroupAssessor) Assess(fileMap types.FileMap) ([]*types.Assessment, error
 
 		for scanner.Scan() {
 			line := scanner.Text()
+			if len(line) == 0 || line[0] == '#' {
+				continue
+			}
 			data := strings.Split(line, ":")
+			if len(data) < 3 {
+				log.Logger.Debug("The group format may be invalid.", line)
+				continue
+			}
 			gname := data[0]
 			gid := data[2]
 

--- a/pkg/assessor/group/group_test.go
+++ b/pkg/assessor/group/group_test.go
@@ -1,0 +1,53 @@
+package group
+
+import (
+	"os"
+	"testing"
+
+	"github.com/goodwithtech/dockle/pkg/log"
+	"github.com/goodwithtech/dockle/pkg/types"
+)
+
+func TestMain(m *testing.M) {
+	if err := log.InitLogger(false, true); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
+
+func TestAssessMalformedLines(t *testing.T) {
+	// etc/group body with a valid row, a blank line, a comment line and a
+	// short/truncated entry. The short and blank lines used to panic on data[2].
+	body := "root:x:0:\n\n# a comment\ndaemon:x:1:\nbroken\nalsobroken:x\n"
+	fileMap := types.FileMap{
+		"etc/group": types.FileData{Body: []byte(body)},
+	}
+
+	assessor := GroupAssessor{}
+	if _, err := assessor.Assess(fileMap); err != nil {
+		t.Fatalf("Assess returned an error: %v", err)
+	}
+}
+
+func TestAssessDuplicateGID(t *testing.T) {
+	// two rows share GID 0, so a duplicate-group assessment is expected.
+	body := "root:x:0:\ndup:x:0:\n"
+	fileMap := types.FileMap{
+		"etc/group": types.FileData{Body: []byte(body)},
+	}
+
+	assessor := GroupAssessor{}
+	assesses, err := assessor.Assess(fileMap)
+	if err != nil {
+		t.Fatalf("Assess returned an error: %v", err)
+	}
+	found := false
+	for _, a := range assesses {
+		if a.Code == types.AvoidDuplicateUserGroup && a.Filename == "etc/group" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a duplicate group assessment, got %v", assesses)
+	}
+}

--- a/pkg/assessor/user/user.go
+++ b/pkg/assessor/user/user.go
@@ -28,7 +28,14 @@ func (a UserAssessor) Assess(fileMap types.FileMap) ([]*types.Assessment, error)
 		uidMap := map[string]struct{}{}
 		for scanner.Scan() {
 			line := scanner.Text()
+			if len(line) == 0 || line[0] == '#' {
+				continue
+			}
 			data := strings.Split(line, ":")
+			if len(data) < 3 {
+				log.Logger.Debug("The passwd format may be invalid.", line)
+				continue
+			}
 			uname := data[0]
 			uid := data[2]
 

--- a/pkg/assessor/user/user_test.go
+++ b/pkg/assessor/user/user_test.go
@@ -1,0 +1,53 @@
+package user
+
+import (
+	"os"
+	"testing"
+
+	"github.com/goodwithtech/dockle/pkg/log"
+	"github.com/goodwithtech/dockle/pkg/types"
+)
+
+func TestMain(m *testing.M) {
+	if err := log.InitLogger(false, true); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
+
+func TestAssessMalformedLines(t *testing.T) {
+	// etc/passwd body with a valid row, a blank line, a comment line and a
+	// short/truncated entry. The short and blank lines used to panic on data[2].
+	body := "root:x:0:0:root:/root:/bin/sh\n\n# a comment\ndaemon:x:1:1:daemon:/:/sbin/nologin\nbroken\nalsobroken:x\n"
+	fileMap := types.FileMap{
+		"etc/passwd": types.FileData{Body: []byte(body)},
+	}
+
+	assessor := UserAssessor{}
+	if _, err := assessor.Assess(fileMap); err != nil {
+		t.Fatalf("Assess returned an error: %v", err)
+	}
+}
+
+func TestAssessDuplicateUID(t *testing.T) {
+	// two rows share UID 0, so a duplicate-user assessment is expected.
+	body := "root:x:0:0:root:/root:/bin/sh\ndup:x:0:0:dup:/:/bin/sh\n"
+	fileMap := types.FileMap{
+		"etc/passwd": types.FileData{Body: []byte(body)},
+	}
+
+	assessor := UserAssessor{}
+	assesses, err := assessor.Assess(fileMap)
+	if err != nil {
+		t.Fatalf("Assess returned an error: %v", err)
+	}
+	found := false
+	for _, a := range assesses {
+		if a.Code == types.AvoidDuplicateUserGroup && a.Filename == "etc/passwd" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a duplicate user assessment, got %v", assesses)
+	}
+}


### PR DESCRIPTION
Hi, I do supply-chain security work and was looking at how dockle parses files pulled out of a scanned image. I found a crash on malformed input in two of the assessors.

The group and user assessors read `/etc/group` and `/etc/passwd` like this:

```go
data := strings.Split(line, ":")
gname := data[0]
gid := data[2]
```

There is no length check before `data[2]`, so any line with fewer than three colon-separated fields blows up with `index out of range [2]`. That covers a blank line in the middle of the file, a comment line, or any truncated/malformed entry. Since the file contents come straight from the layers of whatever image is being scanned, and there is no `recover()` on the scan path, one odd line crashes the whole run.

The passwd assessor next door already handles this correctly: it skips empty and `#` lines and checks the field count before indexing. This change just brings the same guard to group.go and user.go, so short lines are skipped (with a debug log) instead of panicking.

I added unit tests for both assessors that feed a body containing a valid row, a blank line, a comment line and a couple of short entries. Before the change `Assess` panics on those; after it, it returns cleanly. The tests also keep a case for the existing duplicate GID/UID detection so that behavior stays covered.

`go test ./pkg/assessor/...` passes.
